### PR TITLE
Adding new var env due to recent changes on SDX-LC

### DIFF
--- a/env/ampath-lc.env
+++ b/env/ampath-lc.env
@@ -9,6 +9,7 @@ export OXP_PULL_URL=http://ampath:8181/api/kytos/sdx/topology/2.0.0
 export OXP_PULL_INTERVAL=180
 export SDXLC_DOMAIN=ampath.net
 export SUB_QUEUE=connection
+export PUB_QUEUE=oxp_update
 export MQ_HOST=mq1
 export MQ_PORT=5672
 export MQ_USER=testsdx1

--- a/env/sax-lc.env
+++ b/env/sax-lc.env
@@ -9,6 +9,7 @@ export OXP_PULL_URL=http://sax:8181/api/kytos/sdx/topology/2.0.0
 export OXP_PULL_INTERVAL=180
 export SDXLC_DOMAIN=sax.net
 export SUB_QUEUE=connection
+export PUB_QUEUE=oxp_update
 export MQ_HOST=mq1
 export MQ_PORT=5672
 export MQ_USER=testsdx1

--- a/env/tenet-lc.env
+++ b/env/tenet-lc.env
@@ -9,6 +9,7 @@ export OXP_PULL_URL=http://tenet:8181/api/kytos/sdx/topology/2.0.0
 export OXP_PULL_INTERVAL=180
 export SDXLC_DOMAIN=tenet.ac.za
 export SUB_QUEUE=connection
+export PUB_QUEUE=oxp_update
 export MQ_HOST=mq1
 export MQ_PORT=5672
 export MQ_USER=testsdx1


### PR DESCRIPTION
As per recent  changes on SDX-LC, now we have two new var envs to specify the name of the queues. Although the default values were meeting the ones we use on SDX-COntroller, this PR explicitly define the name to avoid future problems.