### PR TITLE
add network dict with ipv6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       interval: 5s
       timeout: 5s
       retries: 60
+    networks:
+      - sdxnet
   mq1:
     image: rabbitmq:latest
     pull_policy: always
@@ -19,6 +21,8 @@ services:
       interval: 5s
       timeout: 5s
       retries: 60
+    networks:
+      - sdxnet
   ampath:
     image: amlight/kytos-sdx:latest
     pull_policy: always
@@ -40,6 +44,8 @@ services:
         rsyslogd
         kytosd --database mongodb
         tail -f /dev/null
+    networks:
+      - sdxnet
   sax:
     image: amlight/kytos-sdx:latest
     pull_policy: always
@@ -61,6 +67,8 @@ services:
         rsyslogd
         kytosd --database mongodb
         tail -f /dev/null
+    networks:
+      - sdxnet
   tenet:
     image: amlight/kytos-sdx:latest
     pull_policy: always
@@ -82,6 +90,8 @@ services:
         rsyslogd
         kytosd --database mongodb
         tail -f /dev/null
+    networks:
+      - sdxnet
   ampath-lc:
     image: awsdx/sdx-lc:latest
     pull_policy: always
@@ -105,6 +115,8 @@ services:
         python3 /sdx-end-to-end-tests/wait-rabbit.py
         python3 -m uvicorn sdx_lc.app:asgi_app --host 0.0.0.0 --port 8080
     command: [""]
+    networks:
+      - sdxnet
   sax-lc:
     image: awsdx/sdx-lc:latest
     pull_policy: always
@@ -128,6 +140,8 @@ services:
         python3 /sdx-end-to-end-tests/wait-rabbit.py
         python3 -m uvicorn sdx_lc.app:asgi_app --host 0.0.0.0 --port 8080
     command: [""]
+    networks:
+      - sdxnet
   tenet-lc:
     image: awsdx/sdx-lc:latest
     pull_policy: always
@@ -151,6 +165,8 @@ services:
         python3 /sdx-end-to-end-tests/wait-rabbit.py
         python3 -m uvicorn sdx_lc.app:asgi_app --host 0.0.0.0 --port 8080
     command: [""]
+    networks:
+      - sdxnet
   sdx-controller:
     image: awsdx/sdx-controller:latest
     pull_policy: always
@@ -174,6 +190,8 @@ services:
         python3 /sdx-end-to-end-tests/wait-rabbit.py
         python3 -m uvicorn sdx_controller.app:asgi_app --host 0.0.0.0 --port 8080
     command: [""]
+    networks:
+      - sdxnet
   mininet:
     image: italovalcy/mininet:latest
     pull_policy: always
@@ -194,3 +212,12 @@ services:
         apt-get update && apt-get install -y tmux jq python3-pytest python3-requests
         python3 -m pip install -r requirements.txt
         tail -f /dev/null
+    networks:
+      - sdxnet
+networks:
+   sdxnet:
+     enable_ipv6: true
+     ipam:
+       config:
+         - subnet: 2001:db8::/64
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -198,11 +198,14 @@ services:
     privileged: true
     volumes:
       - .:/sdx-end-to-end-tests
+      - /lib/modules:/lib/modules
     working_dir: /sdx-end-to-end-tests
     depends_on:
       - ampath
       - sax
       - tenet
+    environment:
+      PYTHONDONTWRITEBYTECODE: "1"
     entrypoint:
       - "/bin/bash"
       - "-x"


### PR DESCRIPTION
network dictionary added to the docker-compose.yml with IPv6 subnet enabled.
services are attached to the (docker) network.
This addition will make the containers be connected to an IPv6 subnet, so that on IPv6-only hosts (eg. FABRIC sites STAR, HAWI) can be used to run the tests.

```
[root@lc-1 sdx-end-to-end-tests]# docker network ls
NETWORK ID     NAME                          DRIVER    SCOPE
f3b959b269ec   bridge                        bridge    local
262f06b3058d   host                          host      local
5115eff50ed0   none                          null      local
c91791a18c7a   sdx-end-to-end-tests_sdxnet   bridge    local
[root@lc-1 sdx-end-to-end-tests]# docker network inspect sdx-end-to-end-tests_sdxnet
[
    {
        "Name": "sdx-end-to-end-tests_sdxnet",
        "Id": "c91791a18c7af51b2f2d33dbca0d6fd86012658cc6202d28f79e6367461f8e6e",
        "Created": "2025-01-27T21:26:02.639905692Z",
        "Scope": "local",
        "Driver": "bridge",
        "EnableIPv6": true,
        "IPAM": {
            "Driver": "default",
            "Options": null,
            "Config": [
                {
                    "Subnet": "2001:db8::/64"
                },
                {
                    "Subnet": "172.23.0.0/16",
                    "Gateway": "172.23.0.1"
                }
            ]
        },
        "Internal": false,
        "Attachable": false,
        "Ingress": false,
        "ConfigFrom": {
            "Network": ""
        },
        "ConfigOnly": false,
        "Containers": {
            "601424bf146979a23b1007e79206cfd978f4ffe13aee6cd6ef3944a06031b64d": {
                "Name": "sdx-end-to-end-tests-ampath-1",
                "EndpointID": "09bc97b0b252b3f286f334251c98a5482e96e5d7324269ce3331209a0c4e0603",
                "MacAddress": "02:42:ac:17:00:08",
                "IPv4Address": "172.23.0.8/16",
                "IPv6Address": "2001:db8::8/64"
            },
            "60bd6f68f386256c3d0e6f36583c8e233f4c9b8916f5d3f06144b99230112076": {
                "Name": "sdx-end-to-end-tests-sax-lc-1",
                "EndpointID": "e0fd8dc75bf3414e360fd1771bcf4f64d1e4571717db3e52e6612511b48403a8",
                "MacAddress": "02:42:ac:17:00:06",
                "IPv4Address": "172.23.0.6/16",
                "IPv6Address": "2001:db8::6/64"
            },
            "6ee9d7a252a5d19c594acd2d88892cd12b5554f4205fa780904bc61700defbfe": {
                "Name": "sdx-end-to-end-tests-ampath-lc-1",
                "EndpointID": "41f8490b8d752adb3470cc2164ea1ab0d747303f5de2e838b2594621a37af9da",
                "MacAddress": "02:42:ac:17:00:07",
                "IPv4Address": "172.23.0.7/16",
                "IPv6Address": "2001:db8::7/64"
            },
            "96dd0d729c6fc507737a773ff329fe3dd70e0383d92db0c6bfdce2ba79793e86": {
                "Name": "sdx-end-to-end-tests-sdx-controller-1",
                "EndpointID": "9bee32469ebd082f62fa1fc087075d08cb0b4dd41f9c2966c48c0729bc343c86",
                "MacAddress": "02:42:ac:17:00:04",
                "IPv4Address": "172.23.0.4/16",
                "IPv6Address": "2001:db8::4/64"
            },
            "9929f9d5663721d33f72597aeef13e93f0398daf79e0fcd273cc49e1b82cc893": {
                "Name": "sdx-end-to-end-tests-tenet-1",
                "EndpointID": "f4e0aeee4d9bbabd54ca428984f3f5176e43d10b846911427c92fab3aba4fc6c",
                "MacAddress": "02:42:ac:17:00:09",
                "IPv4Address": "172.23.0.9/16",
                "IPv6Address": "2001:db8::9/64"
            },
            "bbe93057ee4be4bbead9964208944faf3dc4dced3bd297bd1b3cd6c48d39f94a": {
                "Name": "sdx-end-to-end-tests-sax-1",
                "EndpointID": "6261dc6df8ae9dc7457c7963ac4db2dc7dc034845a8ca46d73f53f760deb6d4a",
                "MacAddress": "02:42:ac:17:00:0a",
                "IPv4Address": "172.23.0.10/16",
                "IPv6Address": "2001:db8::a/64"
            },
            "c53b67cfc5dd6ad96ce644683cbc9d23ef90a3e8392fde6bdfe4f4acc2202cf0": {
                "Name": "sdx-end-to-end-tests-mongo-1",
                "EndpointID": "14ada06a5166a5532821a391b748901e442def866f4271ac3bce54c081a43dd8",
                "MacAddress": "02:42:ac:17:00:03",
                "IPv4Address": "172.23.0.3/16",
                "IPv6Address": "2001:db8::3/64"
            },
            "cdec07e61d19bad48520d71ec1f4583e472838ca653f17fdda93af443e956450": {
                "Name": "sdx-end-to-end-tests-mq1-1",
                "EndpointID": "029c4f3cc5aec74a37d4c8b5f1912c75e459220d75552440efe8cf040bae14b9",
                "MacAddress": "02:42:ac:17:00:02",
                "IPv4Address": "172.23.0.2/16",
                "IPv6Address": "2001:db8::2/64"
            },
            "d763b0841aa9840fff68fc8a94dec1f859f0c9ebd14a94d4a60d46b3e6236c8d": {
                "Name": "sdx-end-to-end-tests-mininet-1",
                "EndpointID": "393d90a1f118e4891fef7b7a2db2ef206a27e461307781626b75e226ec7c63be",
                "MacAddress": "02:42:ac:17:00:0b",
                "IPv4Address": "172.23.0.11/16",
                "IPv6Address": "2001:db8::b/64"
            },
            "fe19f80dad7128c4b845e6638597006b6324b7003249def32d8e35cd21ba6901": {
                "Name": "sdx-end-to-end-tests-tenet-lc-1",
                "EndpointID": "62f6b3731186e2450361f8a36e07d924e3cba14db5f44e695c9052d2189957fc",
                "MacAddress": "02:42:ac:17:00:05",
                "IPv4Address": "172.23.0.5/16",
                "IPv6Address": "2001:db8::5/64"
            }
        },
        "Options": {},
        "Labels": {
            "com.docker.compose.network": "sdxnet",
            "com.docker.compose.project": "sdx-end-to-end-tests",
            "com.docker.compose.version": "2.27.0"
        }
    }
]


[root@lc-1 sdx-end-to-end-tests]# docker compose exec -it mininet ip a | grep eth0
68: eth0@if69: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default 
    inet 172.23.0.11/16 brd 172.23.255.255 scope global eth0
[root@lc-1 sdx-end-to-end-tests]# docker compose exec -it mininet ip a | grep -A 10 eth0
68: eth0@if69: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default 
    link/ether 02:42:ac:17:00:0b brd ff:ff:ff:ff:ff:ff link-netnsid 0
    inet 172.23.0.11/16 brd 172.23.255.255 scope global eth0
       valid_lft forever preferred_lft forever
    inet6 2001:db8::b/64 scope global nodad 
       valid_lft forever preferred_lft forever
    inet6 fe80::42:acff:fe17:b/64 scope link 
       valid_lft forever preferred_lft forever


root@lc-1 sdx-end-to-end-tests]# docker compose exec -it mininet ping -c 3 google.com
PING google.com(bj-in-f139.1e100.net (2607:f8b0:4004:c0b::8b)) 56 data bytes
64 bytes from bj-in-f139.1e100.net (2607:f8b0:4004:c0b::8b): icmp_seq=1 ttl=48 time=124 ms
64 bytes from bj-in-f139.1e100.net (2607:f8b0:4004:c0b::8b): icmp_seq=2 ttl=48 time=118 ms
64 bytes from bj-in-f139.1e100.net (2607:f8b0:4004:c0b::8b): icmp_seq=3 ttl=48 time=109 ms

--- google.com ping statistics ---
3 packets transmitted, 3 received, 0% packet loss, time 2002ms
rtt min/avg/max/mdev = 108.757/116.944/124.078/6.298 ms


[root@lc-1 sdx-end-to-end-tests]# docker compose exec -it mininet python3 -m pytest tests/
========================================================================== test session starts ===========================================================================
platform linux -- Python 3.11.2, pytest-7.2.1, pluggy-1.0.0+repack
rootdir: /sdx-end-to-end-tests
plugins: unordered-0.6.1
collected 44 items                                                                                                                                                       

tests/test_01_topology.py 

```