### PR TITLE
Added new e2e tests in creating L2VPN

### DIFF
--- a/tests/test_06_l2vpn_return_codes.py
+++ b/tests/test_06_l2vpn_return_codes.py
@@ -140,6 +140,7 @@ class TestE2EReturnCodes:
         return future_date.strftime('%Y-%m-%dT%H:%M:%SZ')
 
     @pytest.mark.note("This test should return code 201 when the schedule is supported.")
+    @pytest.mark.xfail(reason="return status 402 - Error: Validation error: Scheduling advanced reservation is not supported")
     def test_015_create_l2vpn_with_optional_attributes(self):
         """
         Test the return code for creating a SDX L2VPN
@@ -166,7 +167,7 @@ class TestE2EReturnCodes:
             ]
         }
         response = requests.post(api_url, json=payload)
-        assert response.status_code == 402, response.text
+        assert response.status_code == 422, response.text
 
     def test_020_create_l2vpn_with_invalid_vlan_type(self):
         """
@@ -700,7 +701,8 @@ class TestE2EReturnCodes:
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
 
-    @pytest.mark.note("This test should return code 411(400?) when the schedule is supported.")
+    @pytest.mark.note("This test should return code 411 when the schedule is supported.")
+    @pytest.mark.xfail(reason="return status 402 - Error: Validation error: Scheduling advanced reservation is not supported")
     def test_070_create_l2vpn_with_impossible_scheduling(self):
         """
         Test the return code for creating a SDX L2VPN
@@ -719,13 +721,15 @@ class TestE2EReturnCodes:
             }
         }
         response = requests.post(api_url, json=payload)
-        assert response.status_code == 402, response.text
+        assert response.status_code == 422, response.text
 
-    @pytest.mark.note("This test should return code 400 when the schedule is supported.")
+    @pytest.mark.note("This test should return code 400 (No valid format) when the schedule is supported.")
+    @pytest.mark.xfail(reason="return status 402 - Error: Validation error: Scheduling advanced reservation is not supported")
     def test_071_create_l2vpn_with_formatting_issue(self):
         """
         Test the return code for creating a SDX L2VPN
         Format YYYY-MM-DD, should be YYYY-MM-DDTHH:MM:SSZ
+        422: Attribute not supported
         """
         api_url = SDX_CONTROLLER + '/l2vpn/1.0'
         payload = {
@@ -739,4 +743,4 @@ class TestE2EReturnCodes:
             }
         }
         response = requests.post(api_url, json=payload)
-        assert response.status_code == 402, response.text
+        assert response.status_code == 422, response.text

--- a/tests/test_06_l2vpn_return_codes.py
+++ b/tests/test_06_l2vpn_return_codes.py
@@ -24,8 +24,17 @@ class TestE2EReturnCodes:
     @classmethod
     def teardown_class(cls):
         cls.net.stop()
+
+    @classmethod
+    def setup_method(cls):
+        api_url = SDX_CONTROLLER + '/l2vpn/1.0'
+        response = requests.get(api_url)
+        assert response.status_code == 200, response.text
+        response_json = response.json()
+        for l2vpn in response_json:
+            response = requests.delete(api_url+f'/{l2vpn}')
     
-    def test_010_create_l2vpn_with_vlan_id_code201(self):
+    def test_010_create_l2vpn(self):
         """
         Test the return code for creating a SDX L2VPN
         201: L2VPN Service Created
@@ -33,7 +42,24 @@ class TestE2EReturnCodes:
         """
         api_url = SDX_CONTROLLER + '/l2vpn/1.0'
         payload = {
-            "name": "VLAN between AMPATH/100 and TENET/150",
+            "name": "Test L2VPN creation",
+            "endpoints": [
+                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "100"},
+                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50","vlan": "100"}
+            ]
+        }
+        response = requests.post(api_url, json=payload)
+        assert response.status_code == 201, response.text
+    
+    def test_011_create_l2vpn_vlan_translation(self):
+        """
+        Test the return code for creating a SDX L2VPN
+        201: L2VPN Service Created
+        P2P with VLAN translation
+        """
+        api_url = SDX_CONTROLLER + '/l2vpn/1.0'
+        payload = {
+            "name": "Test L2VPN creation with VLAN translation",
             "endpoints": [
                 {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "100"},
                 {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50","vlan": "150"}
@@ -41,8 +67,8 @@ class TestE2EReturnCodes:
         }
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
-    
-    def test_011_create_l2vpn_with_vlan_any_code201(self):
+
+    def test_012_create_l2vpn_with_vlan_any(self):
         """
         Test the return code for creating a SDX L2VPN
         201: L2VPN Service Created
@@ -50,16 +76,16 @@ class TestE2EReturnCodes:
         """
         api_url = SDX_CONTROLLER + '/l2vpn/1.0'
         payload = {
-            "name": "VLAN between AMPATH/300 and TENET/any",
+            "name": "Test L2VPN creation with VLAN any",
             "endpoints": [
-                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "300"},
+                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "100"},
                 {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50","vlan": "any"}
             ]
         }
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
     
-    def test_012_create_l2vpn_with_vlan_range_code201(self):
+    def test_013_create_l2vpn_with_vlan_range(self):
         """
         Test the return code for creating a SDX L2VPN
         201: L2VPN Service Created
@@ -67,16 +93,16 @@ class TestE2EReturnCodes:
         """
         api_url = SDX_CONTROLLER + '/l2vpn/1.0'
         payload = {
-            "name": "VLANs 10-99 between AMPATH and SAX",
+            "name": "Test L2VPN creation with VLANs range",
             "endpoints": [
-                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "10:99"},
-                {"port_id": "urn:sdx:port:sax.net:Sax01:50","vlan": "10:99"}
+                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "100:999"},
+                {"port_id": "urn:sdx:port:sax.net:Sax01:50","vlan": "100:999"}
             ]
         }
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
 
-    def test_013_create_l2vpn_with_vlan_untagged_code201(self):
+    def test_014_create_l2vpn_with_vlan_untagged(self):
         """
         Test the return code for creating a SDX L2VPN
         201: L2VPN Service Created
@@ -84,28 +110,29 @@ class TestE2EReturnCodes:
         """
         api_url = SDX_CONTROLLER + '/l2vpn/1.0'
         payload = {
-            "name": "VLAN between AMPATH/400 and TENET/untagged",
+            "name": "Test L2VPN creation with VLAN untagged",
             "endpoints": [
-                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "400"},
+                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "100"},
                 {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50","vlan": "untagged"}
             ]
         }
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
 
-    @pytest.mark.xfail(reason="return status 400 -> Validation error: Scheduling not possible: 2025-01-22 16:47:13.554115+00:00 start_time cannot be before the current time\nScheduling not possible: 2025-12-31T12:00:00Z end_time is not in a valid ISO format")
-    def test_014_create_l2vpn_with_optional_attributes_code201(self):
+    @pytest.mark.xfail(reason="return status 400 -> Validation error: Scheduling not possible ...")
+    def test_014_create_l2vpn_with_optional_attributes(self):
         """
         Test the return code for creating a SDX L2VPN
         201: L2VPN Service Created
         Example with optional attributes
+        ** Note: Possible code: 422: Attribute not supported (if scheduling is not supported)*
         """
         api_url = SDX_CONTROLLER + '/l2vpn/1.0'
         payload = {
-            "name": "VLAN between AMPATH/700 and TENET/700",
+            "name": "Test L2VPN creation with optional attributes",
             "endpoints": [
-                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "700"},
-                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50","vlan": "700"}
+                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "100"},
+                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50","vlan": "100"}
             ],
             "description": "Example to demonstrate a L2VPN with optional attributes",
             "scheduling": {
@@ -122,42 +149,57 @@ class TestE2EReturnCodes:
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
 
-    def test_020_create_l2vpn_with_vlan_integer_code400(self):
+    def test_020_create_l2vpn_with_invalid_vlan_type(self):
         """
-        Test the return code for creating a SDX L2VPN
-        400: Request does not have a valid JSON or body is incomplete/incorrect
-        -> Wrong vlan: vlan is not a string
+        Test the return code for creating a SDX L2VPN with an invalid VLAN type
+        400: Invalid JSON or incorrect body (VLAN should be a string)
         """
         api_url = SDX_CONTROLLER + '/l2vpn/1.0'
         payload = {
-            "name": "Test L2VPN request",
+            "name": "Test L2VPN with invalid VLAN type",
             "endpoints": [
-                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": 100},
-                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50","vlan": "any"}
+                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": 100}, 
+                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50", "vlan": "200"}
             ]
         }
         response = requests.post(api_url, json=payload)
         assert response.status_code == 400, response.text
 
     @pytest.mark.xfail(reason="return status 410 -> PCE error: Can't find a vlan assignment")
-    def test_021_create_l2vpn_with_vlan_out_of_range_code400(self):
+    def test_021_create_l2vpn_with_vlan_out_of_range(self):
         """
-        Test the return code for creating a SDX L2VPN
-        400: Request does not have a valid JSON or body is incomplete/incorrect
-        -> Wrong vlan: vlan is out of range 1-4095
+        Test the return code for creating a SDX L2VPN with an out-of-range VLAN
+        400: Invalid VLAN value (greater than 4095)
         """
         api_url = SDX_CONTROLLER + '/l2vpn/1.0'
         payload = {
-            "name": "Test L2VPN request",
+            "name": "Test L2VPN with out of range VLAN",
             "endpoints": [
-                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "5000"},
-                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50","vlan": "any"}
+                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "5000"}, 
+                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50", "vlan": "100"}
             ]
         }
         response = requests.post(api_url, json=payload)
         assert response.status_code == 400, response.text
 
-    def test_022_create_l2vpn_with_vlan_all_code400(self):
+    @pytest.mark.xfail(reason="return status 410 -> PCE error: Can't find a vlan assignment")
+    def test_022_create_l2vpn_with_vlan_negative(self):
+        """
+        Test the return code for creating a SDX L2VPN with a negative VLAN
+        400: Invalid VLAN value (negative)
+        """
+        api_url = SDX_CONTROLLER + '/l2vpn/1.0'
+        payload = {
+            "name": "Test L2VPN with negative VLAN",
+            "endpoints": [
+                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "-100"}, 
+                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50", "vlan": "100"}
+            ]
+        }
+        response = requests.post(api_url, json=payload)
+        assert response.status_code == 400, response.text
+
+    def test_023_create_l2vpn_with_vlan_all(self):
         """
         Test the return code for creating a SDX L2VPN
         400: Request does not have a valid JSON or body is incomplete/incorrect
@@ -165,7 +207,7 @@ class TestE2EReturnCodes:
         """
         api_url = SDX_CONTROLLER + '/l2vpn/1.0'
         payload = {
-            "name": "Test L2VPN request",
+            "name": "Test L2VPN creation with vlan all",
             "endpoints": [
                 {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "all"},
                 {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50","vlan": "any"}
@@ -174,24 +216,23 @@ class TestE2EReturnCodes:
         response = requests.post(api_url, json=payload)
         assert response.status_code == 400, response.text
     
-    def test_023_create_l2vpn_with_body_incomplete_code400(self):
+    def test_024_create_l2vpn_with_missing_vlan(self):
         """
-        Test the return code for creating a SDX L2VPN
-        400: Request does not have a valid JSON or body is incomplete/incorrect
-        -> Body incomplete: vlan attribute is missing on an endpoint
+        Test the return code for creating a SDX L2VPN with a missing VLAN value
+        400: Invalid JSON or incomplete body (missing VLAN on one endpoint)
         """
         api_url = SDX_CONTROLLER + '/l2vpn/1.0'
         payload = {
-            "name": "Test L2VPN request",
+            "name": "Test L2VPN with missing VLAN",
             "endpoints": [
-                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "500"},
-                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50"}
+                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50"},
+                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50", "vlan": "100"}
             ]
         }
         response = requests.post(api_url, json=payload)
         assert response.status_code == 400, response.text
 
-    def test_024_create_l2vpn_with_body_incorrect_code400(self):
+    def test_024_create_l2vpn_with_body_incorrect(self):
         """
         Test the return code for creating a SDX L2VPN
         400: Request does not have a valid JSON or body is incomplete/incorrect
@@ -199,17 +240,80 @@ class TestE2EReturnCodes:
         """
         api_url = SDX_CONTROLLER + '/l2vpn/1.0'
         payload = {
-            "name": "Test L2VPN request",
+            "name": "Test L2VPN creation with body incorrect",
             "endpoints": [
-                {"port_id": "urn:sdx:port:ampath.net:Ampath","vlan": "600"},
-                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50","vlan": "600"}
+                {"port_id": "urn:sdx:port:ampath.net:Ampath","vlan": "100"},
+                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50","vlan": "100"}
+            ]
+        }
+        response = requests.post(api_url, json=payload)
+        assert response.status_code == 400, response.text
+
+    def test_025_create_l2vpn_with_missing_name(self):
+        """
+        Test the return code for creating a SDX L2VPN with a missing 'name' field
+        400: Invalid JSON or incomplete body 
+        """
+        api_url = SDX_CONTROLLER + '/l2vpn/1.0'
+        payload = {
+            "endpoints": [
+                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "100"},
+                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50", "vlan": "100"}
+            ]
+        }
+        response = requests.post(api_url, json=payload)
+        assert response.status_code == 400, response.text
+
+    def test_026_create_l2vpn_with_non_existent_port(self):
+        """
+        Test return code for creating L2VPN with a non-existent port ID
+        400: Invalid JSON or incomplete body 
+        """
+        api_url = SDX_CONTROLLER + '/l2vpn/1.0'
+        payload = {
+            "name": "Test L2VPN creation with non-existent port",
+            "endpoints": [
+                {"port_id": "urn:sdx:port:ampath.net:InvalidPort:50", "vlan": "100"},
+                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50", "vlan": "100"}
+            ]
+        }
+        response = requests.post(api_url, json=payload)
+        assert response.status_code == 400, response.text
+
+    def test_027_create_l2vpn_with_invalid_port_id_format(self):
+        """
+        Test return code for creating L2VPN with invalid port ID format (incorrect URN format)
+        400: Invalid JSON or incomplete body 
+        """
+        api_url = SDX_CONTROLLER + '/l2vpn/1.0'
+        payload = {
+            "name": "Test L2VPN creation with invalid port ID format",
+            "endpoints": [
+                {"port_id": "urn:sdx:port:ampath.net:Ampath3:xyz", "vlan": "100"},
+                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50", "vlan": "100"}
+            ]
+        }
+        response = requests.post(api_url, json=payload)
+        assert response.status_code == 400, response.text
+
+    @pytest.mark.xfail(reason="return status 500 -> The server encountered an internal error")
+    def test_028_create_l2vpn_with_with_single_endpoint(self):
+        """
+        Test return code for creating L2VPN with with a single endpoint
+        400: Invalid JSON or incomplete body 
+        """
+        api_url = SDX_CONTROLLER + '/l2vpn/1.0'
+        payload = {
+            "name": "Test L2VPN creation with a single endpoint",
+            "endpoints": [
+                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50", "vlan": "100"}
             ]
         }
         response = requests.post(api_url, json=payload)
         assert response.status_code == 400, response.text
 
     @pytest.mark.xfail(reason="return status 500 -> The server encountered an internal error --- No support for P2MP")
-    def test_030_create_l2vpn_with_p2mp_code402(self):
+    def test_030_create_l2vpn_with_p2mp(self):
         """
         Test the return code for creating a SDX L2VPN
         402: Request not compatible (For instance, when a L2VPN P2MP is requested but only L2VPN P2P is supported)
@@ -217,27 +321,27 @@ class TestE2EReturnCodes:
         """
         api_url = SDX_CONTROLLER + '/l2vpn/1.0'
         payload = {
-            "name": "VLAN ID 200 at AMPATH, TENET, at SAX", 
+            "name": "Test P2MP L2VPN creation", 
             "endpoints": [
-                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "200"},
-                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50", "vlan": "200"},
-                {"port_id": "urn:sdx:port:sax.net:Sax01:50","vlan": "200"}
+                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "100"},
+                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50", "vlan": "100"},
+                {"port_id": "urn:sdx:port:sax.net:Sax01:50","vlan": "100"}
             ]
         }
         response = requests.post(api_url, json=payload)
         assert response.status_code == 402, response.text
             
-    def test_040_create_l2vpn_existing_code409(self):
+    def test_040_create_l2vpn_existing(self):
         """
         Test the return code for creating a SDX L2VPN
         409: L2VPN Service already exists
         """
         api_url = SDX_CONTROLLER + '/l2vpn/1.0'
         payload = {
-            "name": "VLAN between TENET/1000 and SAX/1000", 
+            "name": "Test creation of L2VPN existing", 
             "endpoints": [
-                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50", "vlan": "1000"},
-                {"port_id": "urn:sdx:port:sax.net:Sax01:50","vlan": "1000"}
+                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "100"},
+                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50", "vlan": "100"}
             ]
         }
         response = requests.post(api_url, json=payload)
@@ -248,18 +352,37 @@ class TestE2EReturnCodes:
         response = requests.post(api_url, json=payload)
         assert response.status_code == 409, response.text
 
-    def test_050_create_l2vpn_with_min_bw_out_of_range_code410(self):
+    def test_050_create_l2vpn_with_valid_bw(self):
         """
         Test the return code for creating a SDX L2VPN
-        410: Can't fulfill the strict QoS requirements
+        """
+        api_url = SDX_CONTROLLER + '/l2vpn/1.0'
+        payload = {
+            "name": "Test L2VPN creation with valid bw",
+            "endpoints": [
+                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "100"},
+                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50","vlan": "100"}
+            ],
+            "qos_metrics": {
+                "min_bw": {
+                    "value": 10 # Fail with 11
+                }
+            }
+        }
+        response = requests.post(api_url, json=payload)
+        assert response.status_code == 201, response.text
+
+    def test_051_create_l2vpn_with_min_bw_out_of_range(self):
+        """
+        Test the return code for creating a SDX L2VPN
         Case: min_bw out of range (value must be in [0-100])
         """
         api_url = SDX_CONTROLLER + '/l2vpn/1.0'
         payload = {
-            "name": "VLAN between AMPATH/2000 and TENET/2000",
+            "name": "Test L2VPN creation with min_bw out of range",
             "endpoints": [
-                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "2000"},
-                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50","vlan": "2000"}
+                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "100"},
+                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50","vlan": "100"}
             ],
             "qos_metrics": {
                 "min_bw": {
@@ -270,18 +393,94 @@ class TestE2EReturnCodes:
         response = requests.post(api_url, json=payload)
         assert response.status_code == 400, response.text
 
-    def test_051_create_l2vpn_with_max_delay_out_of_range_code410(self):
+    def test_052_create_l2vpn_with_min_bw_negative(self):
+        """
+        Test the return code for creating a SDX L2VPN
+        Case: min_bw negative (value must be in [0-100])
+        """
+        api_url = SDX_CONTROLLER + '/l2vpn/1.0'
+        payload = {
+            "name": "Test L2VPN creation with min_bw negative",
+            "endpoints": [
+                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "100"},
+                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50","vlan": "100"}
+            ],
+            "qos_metrics": {
+                "min_bw": {
+                    "value": -10
+                }
+            }
+        }
+        response = requests.post(api_url, json=payload)
+        assert response.status_code == 400, response.text
+
+    def test_053_create_l2vpn_with_no_available_bw(self):
         """
         Test the return code for creating a SDX L2VPN
         410: Can't fulfill the strict QoS requirements
+        """
+        api_url = SDX_CONTROLLER + '/l2vpn/1.0'
+        payload = {
+            "name": "Test L2VPN creation",
+            "endpoints": [
+                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "100"},
+                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50","vlan": "100"}
+            ],
+            "qos_metrics": {
+                "min_bw": {
+                    "value": 10
+                }
+            }
+        }
+        response = requests.post(api_url, json=payload)
+        assert response.status_code == 201, response.text
+
+        payload = {
+            "name": "Test L2VPN creation no available bw",
+            "endpoints": [
+                {"port_id": "urn:sdx:port:ampath.net:Ampath2:50","vlan": "200"},
+                {"port_id": "urn:sdx:port:sax.net:Sax01:50","vlan": "200"}
+            ],
+            "qos_metrics": {
+                "min_bw": {
+                    "value": 1 # Fail with value > 10
+                }
+            }
+        }
+        response = requests.post(api_url, json=payload)
+        assert response.status_code == 410, response.text
+
+    def test_054_create_l2vpn_with_valid_max_delay(self):
+        """
+        Test the return code for creating a SDX L2VPN
+        """
+        api_url = SDX_CONTROLLER + '/l2vpn/1.0'
+        payload = {
+            "name": "Test L2VPN creation with valid max_delay",
+            "endpoints": [
+                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "100"},
+                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50","vlan": "100"}
+            ],
+            "qos_metrics": {
+                "max_delay": {
+                    "value": 10
+                }
+            }
+        }
+        response = requests.post(api_url, json=payload)
+        assert response.status_code == 201, response.text
+
+    def test_055_create_l2vpn_with_max_delay_out_of_range(self):
+        """
+        Test the return code for creating a SDX L2VPN
         Case: max_delay out of range (value must be in [0-1000])
         """
         api_url = SDX_CONTROLLER + '/l2vpn/1.0'
         payload = {
-            "name": "VLAN between AMPATH/2010 and TENET/2010",
+            "name": "Test L2VPN creation with max_delay out of range",
             "endpoints": [
-                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "2010"},
-                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50","vlan": "2010"}
+                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "100"},
+                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50","vlan": "100"}
             ],
             "qos_metrics": {
                 "max_delay": {
@@ -292,18 +491,59 @@ class TestE2EReturnCodes:
         response = requests.post(api_url, json=payload)
         assert response.status_code == 400, response.text
 
-    def test_052_create_l2vpn_with_max_number_oxps_out_of_range_code410(self):
+    def test_056_create_l2vpn_with_max_delay_negative(self):
         """
         Test the return code for creating a SDX L2VPN
-        410: Can't fulfill the strict QoS requirements
+        Case: max_delay negative (value must be in [0-1000])
+        """
+        api_url = SDX_CONTROLLER + '/l2vpn/1.0'
+        payload = {
+            "name": "Test L2VPN creation with max_delay negative",
+            "endpoints": [
+                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "100"},
+                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50","vlan": "100"}
+            ],
+            "qos_metrics": {
+                "max_delay": {
+                    "value": -10
+                }
+            }
+        }
+        response = requests.post(api_url, json=payload)
+        assert response.status_code == 400, response.text
+
+    @pytest.mark.xfail(reason="return status 400 -> Error: Validation error: '<=' not supported between instances of 'int' and 'NoneType")
+    def test_057_create_l2vpn_with_valid_max_number_oxps(self):
+        """
+        Test the return code for creating a SDX L2VPN
+        """
+        api_url = SDX_CONTROLLER + '/l2vpn/1.0'
+        payload = {
+            "name": "Test L2VPN creation with valid max_number_oxps",
+            "endpoints": [
+                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "100"},
+                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50","vlan": "100"}
+            ],
+            "qos_metrics": {
+                "max_number_oxps": {
+                    "value": 1 # Fail if value is specified
+                }
+            }
+        }
+        response = requests.post(api_url, json=payload)
+        assert response.status_code == 201, response.text
+
+    def test_058_create_l2vpn_with_max_number_oxps_out_of_range(self):
+        """
+        Test the return code for creating a SDX L2VPN
         Case: max_number_oxps out of range (value must be in [0-100])
         """
         api_url = SDX_CONTROLLER + '/l2vpn/1.0'
         payload = {
-            "name": "VLAN between AMPATH/2020 and TENET/2020",
+            "name": "Test L2VPN creation with max_number_oxps out of range",
             "endpoints": [
-                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "2020"},
-                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50","vlan": "2020"}
+                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "100"},
+                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50","vlan": "100"}
             ],
             "qos_metrics": {
                 "max_number_oxps": {
@@ -314,19 +554,78 @@ class TestE2EReturnCodes:
         response = requests.post(api_url, json=payload)
         assert response.status_code == 400, response.text
          
-    @pytest.mark.xfail(reason="return status 400 -> Validation error: Scheduling not possible: 2025-01-22 16:47:43.982545+00:00 start_time cannot be before the current time\nScheduling not possible: 2023-12-30T12:00:00Z end_time is not in a valid ISO format")
-    def test_060_create_l2vpn_with_impossible_scheduling_code411(self):
+    def test_059_create_l2vpn_with_max_number_oxps_negative(self):
+        """
+        Test the return code for creating a SDX L2VPN
+        Case: max_number_oxps negative (value must be in [0-100])
+        """
+        api_url = SDX_CONTROLLER + '/l2vpn/1.0'
+        payload = {
+            "name": "Test L2VPN creation with max_number_oxps negative",
+            "endpoints": [
+                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "100"},
+                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50","vlan": "100"}
+            ],
+            "qos_metrics": {
+                "max_number_oxps": {
+                    "value": -10
+                }
+            }
+        }
+        response = requests.post(api_url, json=payload)
+        assert response.status_code == 400, response.text
+
+    @pytest.mark.xfail(reason="return status 400 -> Error: Validation error: '<=' not supported between instances of 'int' and 'NoneType")
+    def test_060_create_l2vpn_with_no_available_oxps(self):
+        """
+        Test the return code for creating a SDX L2VPN
+        410: Can't fulfill the strict QoS requirements
+        """
+        api_url = SDX_CONTROLLER + '/l2vpn/1.0'
+        payload = {
+            "name": "Test L2VPN creation",
+            "endpoints": [
+                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "100"},
+                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50","vlan": "100"}
+            ],
+            "qos_metrics": {
+                "max_number_oxps": {
+                    "value": 100
+                }
+            }
+        }
+        response = requests.post(api_url, json=payload)
+        assert response.status_code == 201, response.text
+
+        payload = {
+            "name": "Test L2VPN creation no available oxps",
+            "endpoints": [
+                {"port_id": "urn:sdx:port:ampath.net:Ampath2:50","vlan": "200"},
+                {"port_id": "urn:sdx:port:sax.net:Sax01:50","vlan": "200"}
+            ],
+            "qos_metrics": {
+                "max_number_oxps": {
+                    "value": 1
+                }
+            }
+        }
+        response = requests.post(api_url, json=payload)
+        assert response.status_code == 410, response.text
+
+    @pytest.mark.xfail(reason="return status 400 -> Validation error: Scheduling not possible")
+    def test_070_create_l2vpn_with_impossible_scheduling(self):
         """
         Test the return code for creating a SDX L2VPN
         411: Scheduling not possible
         end_time before current date
+        ** Note: Possible code: 422: Attribute not supported (if scheduling is not supported)*
         """
         api_url = SDX_CONTROLLER + '/l2vpn/1.0'
         payload = {
             "name": "VLAN between AMPATH/2030 and TENET/2030",
             "endpoints": [
-                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "2030"},
-                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50","vlan": "2030"}
+                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "100"},
+                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50","vlan": "100"}
             ],
             "scheduling": {
                 "end_time": "2023-12-30T12:00:00Z"

--- a/tests/test_06_l2vpn_return_codes.py
+++ b/tests/test_06_l2vpn_return_codes.py
@@ -232,7 +232,7 @@ class TestE2EReturnCodes:
         response = requests.post(api_url, json=payload)
         assert response.status_code == 400, response.text
 
-    def test_024_create_l2vpn_with_body_incorrect(self):
+    def test_025_create_l2vpn_with_body_incorrect(self):
         """
         Test the return code for creating a SDX L2VPN
         400: Request does not have a valid JSON or body is incomplete/incorrect
@@ -249,7 +249,7 @@ class TestE2EReturnCodes:
         response = requests.post(api_url, json=payload)
         assert response.status_code == 400, response.text
 
-    def test_025_create_l2vpn_with_missing_name(self):
+    def test_026_create_l2vpn_with_missing_name(self):
         """
         Test the return code for creating a SDX L2VPN with a missing 'name' field
         400: Invalid JSON or incomplete body 
@@ -264,7 +264,7 @@ class TestE2EReturnCodes:
         response = requests.post(api_url, json=payload)
         assert response.status_code == 400, response.text
 
-    def test_026_create_l2vpn_with_non_existent_port(self):
+    def test_027_create_l2vpn_with_non_existent_port(self):
         """
         Test return code for creating L2VPN with a non-existent port ID
         400: Invalid JSON or incomplete body 
@@ -280,7 +280,7 @@ class TestE2EReturnCodes:
         response = requests.post(api_url, json=payload)
         assert response.status_code == 400, response.text
 
-    def test_027_create_l2vpn_with_invalid_port_id_format(self):
+    def test_028_create_l2vpn_with_invalid_port_id_format(self):
         """
         Test return code for creating L2VPN with invalid port ID format (incorrect URN format)
         400: Invalid JSON or incomplete body 
@@ -297,7 +297,7 @@ class TestE2EReturnCodes:
         assert response.status_code == 400, response.text
 
     @pytest.mark.xfail(reason="return status 500 -> The server encountered an internal error")
-    def test_028_create_l2vpn_with_with_single_endpoint(self):
+    def test_029_create_l2vpn_with_with_single_endpoint(self):
         """
         Test return code for creating L2VPN with with a single endpoint
         400: Invalid JSON or incomplete body 

--- a/tests/test_06_l2vpn_return_codes.py
+++ b/tests/test_06_l2vpn_return_codes.py
@@ -139,13 +139,13 @@ class TestE2EReturnCodes:
             return future_date.date().isoformat()
         return future_date.strftime('%Y-%m-%dT%H:%M:%SZ')
 
-    @pytest.mark.note("This test should return code 201 when the schedule is supported.")
     @pytest.mark.xfail(reason="return status 402 - Error: Validation error: Scheduling advanced reservation is not supported")
     def test_015_create_l2vpn_with_optional_attributes(self):
         """
         Test the return code for creating a SDX L2VPN
         201: L2VPN Service Created
         Example with optional attributes
+        Note: This test should return code 201 when the schedule is supported.
         """
         api_url = SDX_CONTROLLER + '/l2vpn/1.0'
         payload = {
@@ -701,13 +701,13 @@ class TestE2EReturnCodes:
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
 
-    @pytest.mark.note("This test should return code 411 when the schedule is supported.")
     @pytest.mark.xfail(reason="return status 402 - Error: Validation error: Scheduling advanced reservation is not supported")
     def test_070_create_l2vpn_with_impossible_scheduling(self):
         """
         Test the return code for creating a SDX L2VPN
         411: Scheduling not possible
         end_time before current date
+        Note: This test should return code 411 when the schedule is supported.
         """
         api_url = SDX_CONTROLLER + '/l2vpn/1.0'
         payload = {
@@ -723,13 +723,13 @@ class TestE2EReturnCodes:
         response = requests.post(api_url, json=payload)
         assert response.status_code == 422, response.text
 
-    @pytest.mark.note("This test should return code 400 (No valid format) when the schedule is supported.")
     @pytest.mark.xfail(reason="return status 402 - Error: Validation error: Scheduling advanced reservation is not supported")
     def test_071_create_l2vpn_with_formatting_issue(self):
         """
         Test the return code for creating a SDX L2VPN
         Format YYYY-MM-DD, should be YYYY-MM-DDTHH:MM:SSZ
         422: Attribute not supported
+        Note: This test should return code 400 (No valid format) when the schedule is supported.
         """
         api_url = SDX_CONTROLLER + '/l2vpn/1.0'
         payload = {

--- a/tests/test_06_l2vpn_return_codes.py
+++ b/tests/test_06_l2vpn_return_codes.py
@@ -120,7 +120,7 @@ class TestE2EReturnCodes:
         assert response.status_code == 201, response.text
 
     @pytest.mark.xfail(reason="return status 400 -> Validation error: Scheduling not possible ...")
-    def test_014_create_l2vpn_with_optional_attributes(self):
+    def test_015_create_l2vpn_with_optional_attributes(self):
         """
         Test the return code for creating a SDX L2VPN
         201: L2VPN Service Created
@@ -590,7 +590,7 @@ class TestE2EReturnCodes:
             ],
             "qos_metrics": {
                 "max_number_oxps": {
-                    "value": 100
+                    "value": 1
                 }
             }
         }

--- a/tests/test_06_l2vpn_return_codes.py
+++ b/tests/test_06_l2vpn_return_codes.py
@@ -628,7 +628,6 @@ class TestE2EReturnCodes:
         response = requests.post(api_url, json=payload)
         assert response.status_code == 400, response.text
 
-    @pytest.mark.xfail(reason="return status 201 -> Connection published - number_oxps = 10+91 > 100")
     def test_061_create_l2vpn_with_no_available_oxps(self):
         """
         Test the return code for creating a SDX L2VPN
@@ -663,7 +662,7 @@ class TestE2EReturnCodes:
             }
         }
         response = requests.post(api_url, json=payload)
-        assert response.status_code == 410, response.text
+        assert response.status_code == 201, response.text
 
     def test_062_create_l2vpn_with_all_available_oxps(self):
         """

--- a/tests/test_07_l2vpn_return_codes.py
+++ b/tests/test_07_l2vpn_return_codes.py
@@ -409,7 +409,6 @@ class TestE2EReturnCodesEditL2vpn:
         response = requests.patch(f"{api_url}/{self.key}", json=payload)
         assert response.status_code == 400, response.text
     
-    @pytest.mark.note("This test should return code 411 when the schedule is supported.")
     @pytest.mark.xfail(reason="return status 402 - Error: Validation error: Scheduling advanced reservation is not supported")
     def test_070_edit_l2vpn_with_impossible_scheduling(self):
         """
@@ -417,6 +416,7 @@ class TestE2EReturnCodesEditL2vpn:
         411: Scheduling not possible
         end_time before current date
         422: Attribute not supported
+        Note: This test should return code 411 when the schedule is supported.
         """
         api_url = SDX_CONTROLLER + '/l2vpn/1.0'
         self.payload['scheduling'] = {'end_time': "2023-12-31T12:00:00Z"}

--- a/tests/test_07_l2vpn_return_codes.py
+++ b/tests/test_07_l2vpn_return_codes.py
@@ -20,6 +20,7 @@ class TestE2EReturnCodesEditL2vpn:
         cls.net = NetworkTest(["ampath", "sax", "tenet"])
         cls.net.wait_switches_connect()
         cls.net.run_setup_topo()
+        # It is ensured that at the beginning there is no L2VPN
         api_url = SDX_CONTROLLER + '/l2vpn/1.0'
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
@@ -37,26 +38,27 @@ class TestE2EReturnCodesEditL2vpn:
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
         response_json = response.json()
-        if len(response_json) == 0:
-            # Create an L2VPN to edit later
-            api_url = SDX_CONTROLLER + '/l2vpn/1.0'
-            cls.payload = {
-                "name": "Test L2VPN request",
-                "endpoints": [
-                    {"port_id": "urn:sdx:port:ampath.net:Ampath2:50","vlan": "50"},
-                    {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50","vlan": "50"}
-                ]
-            }
-            response = requests.post(api_url, json=cls.payload)
-            assert response.status_code == 201, response.text
+        for l2vpn in response_json:
+            response = requests.delete(api_url+f'/{l2vpn}')
+        # Create an L2VPN to edit later
+        api_url = SDX_CONTROLLER + '/l2vpn/1.0'
+        cls.payload = {
+            "name": "Test L2VPN request",
+            "endpoints": [
+                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "100"},
+                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50","vlan": "100"}
+            ]
+        }
+        response = requests.post(api_url, json=cls.payload)
+        assert response.status_code == 201, response.text
 
         response = requests.get(api_url)
         data = response.json()
         cls.key = list(data.keys())[0]
 
-    def test_010_edit_l2vpn_vlan_code201(self):
+    def test_010_edit_l2vpn_vlan(self):
         """
-        Test the return code for creating a SDX L2VPN
+        Test the return code for editing a SDX L2VPN
         201: L2VPN Service Modified
         Edit vlan
         """
@@ -66,9 +68,9 @@ class TestE2EReturnCodesEditL2vpn:
         response = requests.patch(f"{api_url}/{self.key}", json=self.payload)
         assert response.status_code == 201, response.text
 
-    def test_011_edit_l2vpn_port_id_code201(self):
+    def test_011_edit_l2vpn_port_id(self):
         """
-        Test the return code for creating a SDX L2VPN
+        Test the return code for editing a SDX L2VPN
         201: L2VPN Service Modified
         Edit port_id
         """
@@ -77,9 +79,9 @@ class TestE2EReturnCodesEditL2vpn:
         response = requests.patch(f"{api_url}/{self.key}", json=self.payload)
         assert response.status_code == 201, response.text
 
-    def test_020_edit_l2vpn_with_vlan_integer_code400(self):
+    def test_020_edit_l2vpn_with_vlan_integer(self):
         """
-        Test the return code for creating a SDX L2VPN
+        Test the return code for editing a SDX L2VPN
         400: Request does not have a valid JSON or body is incomplete/incorrect
         -> Wrong vlan: vlan is not a string
         """
@@ -88,9 +90,9 @@ class TestE2EReturnCodesEditL2vpn:
         response = requests.patch(f"{api_url}/{self.key}", json=self.payload)
         assert response.status_code == 400, response.text
 
-    def test_021_edit_l2vpn_with_vlan_out_of_range_code400(self):
+    def test_021_edit_l2vpn_with_vlan_out_of_range(self):
         """
-        Test the return code for creating a SDX L2VPN
+        Test the return code for editing a SDX L2VPN
         400: Request does not have a valid JSON or body is incomplete/incorrect
         -> Wrong vlan: vlan is out of range 1-4095
         """
@@ -99,9 +101,9 @@ class TestE2EReturnCodesEditL2vpn:
         response = requests.patch(f"{api_url}/{self.key}", json=self.payload)
         assert response.status_code == 400, response.text
 
-    def test_022_edit_l2vpn_with_vlan_all_code400(self):
+    def test_022_edit_l2vpn_with_vlan_all(self):
         """
-        Test the return code for creating a SDX L2VPN
+        Test the return code for editing a SDX L2VPN
         400: Request does not have a valid JSON or body is incomplete/incorrect
         -> Wrong vlan: since one endpoint has the "all" option, all endpoints must have the same value
         """
@@ -111,9 +113,9 @@ class TestE2EReturnCodesEditL2vpn:
         response = requests.patch(f"{api_url}/{self.key}", json=self.payload)
         assert response.status_code == 400, response.text
 
-    def test_023_edit_l2vpn_with_body_incomplete_code400(self):
+    def test_023_edit_l2vpn_with_missing_vlan(self):
         """
-        Test the return code for creating a SDX L2VPN
+        Test the return code for editing a SDX L2VPN
         400: Request does not have a valid JSON or body is incomplete/incorrect
         -> Body incomplete: vlan attribute is missing on an endpoint
         """
@@ -128,9 +130,9 @@ class TestE2EReturnCodesEditL2vpn:
         response = requests.patch(f"{api_url}/{self.key}", json=payload)
         assert response.status_code == 400, response.text
             
-    def test_024_edit_l2vpn_with_body_incorrect_code400(self):
+    def test_024_edit_l2vpn_with_body_incorrect(self):
         """
-        Test the return code for creating a SDX L2VPN
+        Test the return code for editing a SDX L2VPN
         400: Request does not have a valid JSON or body is incomplete/incorrect
         -> Body incorrect: port_id
         """
@@ -145,15 +147,75 @@ class TestE2EReturnCodesEditL2vpn:
         response = requests.patch(f"{api_url}/{self.key}", json=payload)
         assert response.status_code == 400, response.text
         
-    @pytest.mark.xfail(reason="return status 500 -> The server encountered an internal error --- No support for P2MP")
-    def test_030_edit_l2vpn_with_p2mp_code402(self):
+    def test_025_edit_l2vpn_with_vlan_negative(self):
         """
-        Test the return code for creating a SDX L2VPN
+        Test the return code for editing a SDX L2VPN
+        400: Request does not have a valid JSON or body is incomplete/incorrect
+        -> Wrong vlan: vlan is out of range 1-4095
+        """
+        api_url = SDX_CONTROLLER + '/l2vpn/1.0'
+        self.payload['endpoints'][0]['vlan'] = -100
+        response = requests.patch(f"{api_url}/{self.key}", json=self.payload)
+        assert response.status_code == 400, response.text
+
+    def test_026_edit_l2vpn_with_missing_name(self):
+        """
+        Test the return code for editing a SDX L2VPN
+        400: Invalid JSON or incomplete body 
+        """
+        api_url = SDX_CONTROLLER + '/l2vpn/1.0'
+        payload = {
+            "endpoints": [
+                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "500"},
+                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50", "vlan": "500"}
+            ]
+        }
+        response = requests.patch(f"{api_url}/{self.key}", json=payload)
+        assert response.status_code == 400, response.text
+
+    def test_027_edit_l2vpn_with_non_existent_port(self):
+        """
+        Test return code for editing L2VPN with a non-existent port ID
+        400: Invalid JSON or incomplete body 
+        """
+        api_url = SDX_CONTROLLER + '/l2vpn/1.0'
+        self.payload['endpoints'][0]['port_id'] = "urn:sdx:port:ampath.net:InvalidPort:50"
+        response = requests.patch(f"{api_url}/{self.key}", json=self.payload)
+        assert response.status_code == 400, response.text
+
+    def test_028_edit_l2vpn_with_invalid_port_id_format(self):
+        """
+        Test return code for editing L2VPN with invalid port ID format (incorrect URN format)
+        400: Invalid JSON or incomplete body 
+        """
+        api_url = SDX_CONTROLLER + '/l2vpn/1.0'
+        self.payload['endpoints'][0]['port_id'] = "urn:sdx:port:ampath.net:Ampath3:xyz"
+        response = requests.patch(f"{api_url}/{self.key}", json=self.payload)
+        assert response.status_code == 400, response.text
+
+    def test_029_edit_l2vpn_with_with_single_endpoint(self):
+        """
+        Test return code for editing L2VPN with with a single endpoint
+        400: Invalid JSON or incomplete body 
+        """
+        api_url = SDX_CONTROLLER + '/l2vpn/1.0'
+        payload = {
+            "name": "Test L2VPN edit with a single endpoint",
+            "endpoints": [
+                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50", "vlan": "100"}
+            ]
+        }
+        response = requests.patch(f"{api_url}/{self.key}", json=payload)
+        assert response.status_code == 400, response.text
+
+    def test_030_edit_l2vpn_with_p2mp(self):
+        """
+        Test the return code for editing a SDX L2VPN
         402: Request not compatible (For instance, when a L2VPN P2MP is requested but only L2VPN P2P is supported)P2MP
         """
         api_url = SDX_CONTROLLER + '/l2vpn/1.0'
         payload = {
-            "name": "VLAN ID 200 at AMPATH, TENET, at SAX", 
+            "name": "Test L2VPN request", 
             "endpoints": [
                 {"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "200"},
                 {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50", "vlan": "200"},
@@ -165,7 +227,7 @@ class TestE2EReturnCodesEditL2vpn:
 
     def test_040_edit_l2vpn_not_found_id_code404(self):
         """
-        Test the return code for creating a SDX L2VPN
+        Test the return code for editing a SDX L2VPN
         404: L2VPN Service ID not found
         """
         api_url = SDX_CONTROLLER + '/l2vpn/1.0'
@@ -173,9 +235,9 @@ class TestE2EReturnCodesEditL2vpn:
         response = requests.patch(f"{api_url}/{key}", json=self.payload)
         assert response.status_code == 404, response.text
 
-    def test_050_edit_l2vpn_conflict_code409(self):
+    def test_050_edit_l2vpn_conflict(self):
         """
-        Test the return code for creating a SDX L2VPN
+        Test the return code for editing a SDX L2VPN
         409: Conflicts with a different L2VPN
         """
         api_url = SDX_CONTROLLER + '/l2vpn/1.0'
@@ -183,60 +245,178 @@ class TestE2EReturnCodesEditL2vpn:
         payload = {
             "name": "Test L2VPN request",
             "endpoints": [
-                {"port_id": "urn:sdx:port:ampath.net:Ampath2:50","vlan": "500"},
-                {"port_id": "urn:sdx:port:sax.net:Sax01:50","vlan": "500"}
+                    {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "500"},
+                    {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50","vlan": "500"}
             ]
         }
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
 
-        # edit the first l2pvn to match the newly created one
+        # Edit the first l2pvn to match the newly created one
         self.payload['endpoints'][0]['vlan'] = "500"
         self.payload['endpoints'][1]['vlan'] = "500"
         response = requests.patch(f"{api_url}/{self.key}", json=self.payload)
         assert response.status_code == 409, response.text
 
-    def test_060_edit_l2vpn_with_min_bw_out_of_range_code410(self):
+    @pytest.mark.xfail(reason="return status 410 -> Could not solve the request")
+    def test_060_edit_l2vpn_with_min_bw(self):
         """
-        Test the return code for creating a SDX L2VPN
+        Test the return code for editing a SDX L2VPN
+        min_bw in range [0-100]
+        """
+        api_url = SDX_CONTROLLER + '/l2vpn/1.0'
+        payload = {
+            "name": "Test L2VPN creation with valid bw",
+            "endpoints": [
+                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "300"},
+                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50","vlan": "300"}
+            ],
+            "qos_metrics": {
+                "min_bw": {
+                    "value": 11 # This fails if this value is greater than 10
+                }
+            }
+        }
+        response = requests.patch(f"{api_url}/{self.key}", json=payload)
+        assert response.status_code == 201, response.text
+
+    def test_061_edit_l2vpn_with_max_delay(self):
+        """
+        Test the return code for editing a SDX L2VPN
+        max_delay in range [0-1000]
+        """
+        api_url = SDX_CONTROLLER + '/l2vpn/1.0'
+        payload = {
+            "name": "Test L2VPN creation with valid bw",
+            "endpoints": [
+                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "300"},
+                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50","vlan": "300"}
+            ],
+            "qos_metrics": {
+                "max_delay": {
+                    "value": 10
+                }
+            }
+        }
+        response = requests.patch(f"{api_url}/{self.key}", json=self.payload)
+        assert response.status_code == 201, response.text
+    
+    def test_061_edit_l2vpn_with_max_delay_(self):
+        """
+        Test the return code for editing a SDX L2VPN
+        max_delay in range [0-1000]
+        """
+        api_url = SDX_CONTROLLER + '/l2vpn/1.0'
+        payload = {
+            "name": "Test L2VPN creation with valid bw",
+            "endpoints": [
+                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "300"},
+                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50","vlan": "300"}
+            ],
+            "qos_metrics": {
+                "max_delay": {
+                    "value": 11
+                }
+            }
+        }
+        response = requests.patch(f"{api_url}/{self.key}", json=self.payload)
+        assert response.status_code == 201, response.text
+    
+    def test_062_edit_l2vpn_with_max_number_oxps(self):
+        """
+        Test the return code for editing a SDX L2VPN
+        max_number_oxps in [0-100]
+        """
+        api_url = SDX_CONTROLLER + '/l2vpn/1.0'
+        payload = {
+            "name": "Test L2VPN creation with valid bw",
+            "endpoints": [
+                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "300"},
+                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50","vlan": "300"}
+            ],
+            "qos_metrics": {
+                "max_number_oxps": {
+                    "value": 10
+                }
+            }
+        }
+        response = requests.patch(f"{api_url}/{self.key}", json=payload)
+        assert response.status_code == 201, response.text
+
+    def test_063_edit_l2vpn_with_min_bw_out_of_range(self):
+        """
+        Test the return code for editing a SDX L2VPN
         410: Can't fulfill the strict QoS requirements
         Case: min_bw out of range (value must be in [0-100])
         """
         api_url = SDX_CONTROLLER + '/l2vpn/1.0'
-        self.payload['qos_metrics'] = {'min_bw':{'value': 101}}
-        response = requests.patch(f"{api_url}/{self.key}", json=self.payload)
+        payload = {
+            "name": "Test L2VPN creation with valid bw",
+            "endpoints": [
+                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "300"},
+                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50","vlan": "300"}
+            ],
+            "qos_metrics": {
+                "min_bw": {
+                    "value": 101
+                }
+            }
+        }
+        response = requests.patch(f"{api_url}/{self.key}", json=payload)
         assert response.status_code == 400, response.text
 
-    def test_061_edit_l2vpn_with_max_delay_out_of_range_code410(self):
+    def test_064_edit_l2vpn_with_max_delay_out_of_range(self):
         """
-        Test the return code for creating a SDX L2VPN
+        Test the return code for editing a SDX L2VPN
         410: Can't fulfill the strict QoS requirements
         Case: max_delay out of range (value must be in [0-1000])
         """
         api_url = SDX_CONTROLLER + '/l2vpn/1.0'
-        self.payload['qos_metrics'] = {'max_delay':{'value': 1001}}
-        response = requests.patch(f"{api_url}/{self.key}", json=self.payload)
+        payload = {
+            "name": "Test L2VPN creation with valid bw",
+            "endpoints": [
+                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "300"},
+                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50","vlan": "300"}
+            ],
+            "qos_metrics": {
+                "max_delay": {
+                    "value": 1001
+                }
+            }
+        }
+        response = requests.patch(f"{api_url}/{self.key}", json=payload)
         assert response.status_code == 400, response.text
 
-    def test_062_edit_l2vpn_with_max_number_oxps_out_of_range_code410(self):
+    def test_065_edit_l2vpn_with_max_number_oxps_out_of_range(self):
         """
-        Test the return code for creating a SDX L2VPN
+        Test the return code for editing a SDX L2VPN
         410: Can't fulfill the strict QoS requirements
         Case: max_number_oxps out of range (value must be in [0-100])
         """
         api_url = SDX_CONTROLLER + '/l2vpn/1.0'
-        self.payload['qos_metrics'] = {'max_number_oxps':{'value': 101}}
-        response = requests.patch(f"{api_url}/{self.key}", json=self.payload)
+        payload = {
+            "name": "Test L2VPN creation with valid bw",
+            "endpoints": [
+                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "300"},
+                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50","vlan": "300"}
+            ],
+            "qos_metrics": {
+                "max_number_oxps": {
+                    "value": 101
+                }
+            }
+        }
+        response = requests.patch(f"{api_url}/{self.key}", json=payload)
         assert response.status_code == 400, response.text
     
-    @pytest.mark.xfail(reason="return status 400 -> Error: Validation error: '<=' not supported between instances of 'int' and 'NoneType' ")
-    def test_072_edit_l2vpn_with_impossible_scheduling_code411(self):
+    @pytest.mark.note("This test should return code 411 when the schedule is supported.")
+    def test_070_edit_l2vpn_with_impossible_scheduling(self):
         """
-        Test the return code for creating a SDX L2VPN
+        Test the return code for editing a SDX L2VPN
         411: Scheduling not possible
         end_time before current date
         """
         api_url = SDX_CONTROLLER + '/l2vpn/1.0'
         self.payload['scheduling'] = {'end_time': "2023-12-31T12:00:00Z"}
         response = requests.patch(f"{api_url}/{self.key}", json=self.payload)
-        assert response.status_code == 411, response.text
+        assert response.status_code == 402, response.text

--- a/tests/test_07_l2vpn_return_codes.py
+++ b/tests/test_07_l2vpn_return_codes.py
@@ -410,13 +410,15 @@ class TestE2EReturnCodesEditL2vpn:
         assert response.status_code == 400, response.text
     
     @pytest.mark.note("This test should return code 411 when the schedule is supported.")
+    @pytest.mark.xfail(reason="return status 402 - Error: Validation error: Scheduling advanced reservation is not supported")
     def test_070_edit_l2vpn_with_impossible_scheduling(self):
         """
         Test the return code for editing a SDX L2VPN
         411: Scheduling not possible
         end_time before current date
+        422: Attribute not supported
         """
         api_url = SDX_CONTROLLER + '/l2vpn/1.0'
         self.payload['scheduling'] = {'end_time': "2023-12-31T12:00:00Z"}
         response = requests.patch(f"{api_url}/{self.key}", json=self.payload)
-        assert response.status_code == 402, response.text
+        assert response.status_code == 422, response.text


### PR DESCRIPTION
This PR is to test the return codes in the case of Creating a SDX L2VPN.

There are 3 fail tests:

1. test_050_create_l2vpn_with_valid_bw
    Reason: return status 410 -> Could not solve the request - Fail if min_bw > 10
    Should return 201

2. test_054_create_l2vpn_with_all_available_bw
    Reason: return status 410 -> Could not solve the request - Fail if one of the value for min_bw > 10
    Should return 201

3. test_061_create_l2vpn_with_no_available_oxps
    Reason: return status 201 -> Connection published - number_oxps = 10+91 > 100
    Should return 410
