### PR TITLE
Enhance test_07_l2vpn_return_codes to avoid failures

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -185,6 +185,8 @@ services:
       - ampath
       - sax
       - tenet
+    environment:
+      PYTHONDONTWRITEBYTECODE: "1"
     entrypoint:
       - "/bin/bash"
       - "-x"

--- a/tests/test_07_l2vpn_return_codes.py
+++ b/tests/test_07_l2vpn_return_codes.py
@@ -37,22 +37,21 @@ class TestE2EReturnCodesEditL2vpn:
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
         response_json = response.json()
+        cls.payload = {
+            "name": "Test L2VPN request",
+            "endpoints": [
+                {"port_id": "urn:sdx:port:ampath.net:Ampath2:50","vlan": "50"},
+                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50","vlan": "50"}
+            ]
+        }
         if len(response_json) == 0:
             # Create an L2VPN to edit later
             api_url = SDX_CONTROLLER + '/l2vpn/1.0'
-            cls.payload = {
-                "name": "Test L2VPN request",
-                "endpoints": [
-                    {"port_id": "urn:sdx:port:ampath.net:Ampath2:50","vlan": "50"},
-                    {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50","vlan": "50"}
-                ]
-            }
             response = requests.post(api_url, json=cls.payload)
             assert response.status_code == 201, response.text
-
-        response = requests.get(api_url)
-        data = response.json()
-        cls.key = list(data.keys())[0]
+            cls.key = response.json()["service_id"]
+        else:
+            cls.key = list(response_json.keys())[0]
 
     def test_010_edit_l2vpn_vlan_code201(self):
         """


### PR DESCRIPTION
Fix #29 

### Description of the change

if the L2VPN already exists on the setup_method of test_07_l2vpn_return_codes, then a payload was not being recorded and then tests failed. This PR enhances the test_07_l2vpn_return_codes to save payload no matter the result of get all L2VPN.

Besides that, the PR also adds an option to mininet container to avoid pycache files and thus avoid false negative.