### PR TITLE
Change Mininet container spec to mount lib modules

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -180,6 +180,7 @@ services:
     privileged: true
     volumes:
       - .:/sdx-end-to-end-tests
+      - /lib/modules:/lib/modules
     working_dir: /sdx-end-to-end-tests
     depends_on:
       - ampath


### PR DESCRIPTION
As described by Mert on https://github.com/atlanticwave-sdx/sdx-deployment/issues/102 when running the end-to-end tests on a VM with fresh installation, the openvswitch Kernel module usually is not loaded on the VM. Since the standard container does not include /lib/modules, then Mininet container will be unable to load the required kernel module.

This PR adds a new mount point to mininet container for the `/lib/modules` directory, so that the container will be able to load the Kernel module installed on the host.