### PR TITLE
enhance test_013_create_l2vpn_with_vlan_range with more checks

### DIFF
--- a/tests/test_06_l2vpn_return_codes.py
+++ b/tests/test_06_l2vpn_return_codes.py
@@ -95,12 +95,47 @@ class TestE2EReturnCodes:
         payload = {
             "name": "Test L2VPN creation with VLANs range",
             "endpoints": [
-                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "100:999"},
-                {"port_id": "urn:sdx:port:sax.net:Sax01:50","vlan": "100:999"}
+                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "500:999"},
+                {"port_id": "urn:sdx:port:sax.net:Sax01:50","vlan": "500:999"}
             ]
         }
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
+        data = response.json()
+        assert data.get("status") == "under provisioning", data
+        service_id = data.get("service_id")
+        assert service_id != None, data
+
+        # give enough time to SDX-Controller to propagate change to OXPs
+        time.sleep(10)
+
+        response = requests.get(api_url)
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert len(data) == 1, data
+        assert service_id in data, data
+        assert data[service_id].get("status") == "up", data
+
+        #
+        # make sure OXPs have the new EVCs
+        ## -> ampath
+        response = requests.get("http://ampath:8181/api/kytos/mef_eline/v2/evc/")
+        evcs = response.json()
+        assert len(evcs) == 1, response.text
+        found = 0
+        for evc in evcs.values():
+            if evc.get("uni_a", {}).get("tag", {}).get("value") == [[500, 999]]:
+                found += 1
+        assert found == 1, evcs
+        ## -> sax
+        response = requests.get("http://sax:8181/api/kytos/mef_eline/v2/evc/")
+        evcs = response.json()
+        assert len(evcs) == 1, response.text
+        found = 0
+        for evc in evcs.values():
+            if evc.get("uni_z", {}).get("tag", {}).get("value") == [[500, 999]]:
+                found += 1
+        assert found == 1, evcs
 
     def test_014_create_l2vpn_with_vlan_untagged(self):
         """

--- a/tests/test_06_l2vpn_return_codes.py
+++ b/tests/test_06_l2vpn_return_codes.py
@@ -95,8 +95,8 @@ class TestE2EReturnCodes:
         payload = {
             "name": "Test L2VPN creation with VLANs range",
             "endpoints": [
-                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "500:999"},
-                {"port_id": "urn:sdx:port:sax.net:Sax01:50","vlan": "500:999"}
+                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "600:999"},
+                {"port_id": "urn:sdx:port:sax.net:Sax01:50","vlan": "600:999"}
             ]
         }
         response = requests.post(api_url, json=payload)
@@ -124,7 +124,7 @@ class TestE2EReturnCodes:
         assert len(evcs) == 1, response.text
         found = 0
         for evc in evcs.values():
-            if evc.get("uni_a", {}).get("tag", {}).get("value") == [[500, 999]]:
+            if evc.get("uni_a", {}).get("tag", {}).get("value") == [[600, 999]]:
                 found += 1
         assert found == 1, evcs
         ## -> sax
@@ -133,7 +133,7 @@ class TestE2EReturnCodes:
         assert len(evcs) == 1, response.text
         found = 0
         for evc in evcs.values():
-            if evc.get("uni_z", {}).get("tag", {}).get("value") == [[500, 999]]:
+            if evc.get("uni_z", {}).get("tag", {}).get("value") == [[600, 999]]:
                 found += 1
         assert found == 1, evcs
 

--- a/tests/test_06_l2vpn_return_codes.py
+++ b/tests/test_06_l2vpn_return_codes.py
@@ -107,7 +107,7 @@ class TestE2EReturnCodes:
         assert service_id != None, data
 
         # give enough time to SDX-Controller to propagate change to OXPs
-        time.sleep(10)
+        time.sleep(5)
 
         response = requests.get(api_url)
         assert response.status_code == 200, response.text


### PR DESCRIPTION
Fix #73 

### Description of the change

This PR adds two changes on test_013:

1) changes the VLAN range used for test_013 to avoid conflicts with other tests in case something unexpected happens

2) adds more tests to make sure the VLAN range L2VPN was successfully created