### PR TITLE
Enhance checks for creating L2VPN with untagged VLAN

### DIFF
--- a/tests/test_06_l2vpn_return_codes.py
+++ b/tests/test_06_l2vpn_return_codes.py
@@ -151,7 +151,7 @@ class TestE2EReturnCodes:
         payload = {
             "name": "Test L2VPN creation with VLAN untagged",
             "endpoints": [
-                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "100"},
+                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "599"},
                 {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50","vlan": "untagged"}
             ]
         }
@@ -180,7 +180,7 @@ class TestE2EReturnCodes:
         assert len(evcs) == 1, response.text
         found = 0
         for evc in evcs.values():
-            if evc.get("uni_a", {}).get("tag", {}).get("value") == 100:
+            if evc.get("uni_a", {}).get("tag", {}).get("value") == 599:
                 found += 1
         assert found == 1, evcs
         ## -> sax


### PR DESCRIPTION
Fix #79 

Heads-UP: this PR will sits on top of PR #78 

### Description of the change

This PR will enhance checks and validations of test_06/test_014_create_l2vpn_with_vlan_untagged to properly validate the creation of L2VPN.