### PR TITLE
Enhance tests to add more validations and add proper time sleep

### DIFF
--- a/tests/test_05_l2vpn.py
+++ b/tests/test_05_l2vpn.py
@@ -55,10 +55,10 @@ class TestE2EL2VPN:
         }
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
-        response_json = response.json()
-        assert response_json.get("status") == "under provisioning", response_json
-        service_id = response_json.get("service_id")
-        assert service_id != None, response_json
+        data = response.json()
+        assert data.get("status") == "under provisioning", str(data)
+        service_id = data.get("service_id")
+        assert service_id != None, str(data)
 
         # give enough time to SDX-Controller to propagate change to OXPs
         time.sleep(10)
@@ -66,10 +66,10 @@ class TestE2EL2VPN:
         api_url = SDX_CONTROLLER + '/l2vpn/1.0'
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
-        response_json = response.json()
-        assert len(response_json) == 1, response_json
-        assert service_id in response_json, response_json
-        assert response_json[service_id].get("status") == "up", response_json
+        data = response.json()
+        assert len(data) == 1, str(data)
+        assert service_id in data, str(data)
+        assert data[service_id].get("status") == "up", str(data)
 
         # make sure OXPs have the new EVCs
         ## -> ampath
@@ -80,10 +80,11 @@ class TestE2EL2VPN:
         for evc in evcs.values():
             if evc.get("uni_a", {}).get("tag", {}).get("value") == 300:
                 found += 1
-        assert found == 1, evcs
+        assert found == 1, str(evcs)
         ## -> sax
         response = requests.get("http://sax:8181/api/kytos/mef_eline/v2/evc/")
-        assert len(response.json()) == 1, response.json()
+        data = response.json()
+        assert len(data) == 1, str(data)
         ## -> tenet
         response = requests.get("http://tenet:8181/api/kytos/mef_eline/v2/evc/")
         evcs = response.json()
@@ -92,7 +93,7 @@ class TestE2EL2VPN:
         for evc in evcs.values():
             if evc.get("uni_z", {}).get("tag", {}).get("value") == 300:
                 found += 1
-        assert found == 1, evcs
+        assert found == 1, str(evcs)
 
     def test_030_create_l2vpn_with_any_vlan(self):
         """Test creating a L2VPN successfully."""
@@ -112,10 +113,10 @@ class TestE2EL2VPN:
         }
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
-        response_json = response.json()
-        assert response_json.get("status") == "under provisioning", response_json
-        service_id = response_json.get("service_id")
-        assert service_id != None, response_json
+        data = response.json()
+        assert data.get("status") == "under provisioning", str(data)
+        service_id = data.get("service_id")
+        assert service_id != None, str(data)
 
         # give enough time to SDX-Controller to propagate change to OXPs
         time.sleep(10)
@@ -123,10 +124,10 @@ class TestE2EL2VPN:
         api_url = SDX_CONTROLLER + '/l2vpn/1.0'
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
-        response_json = response.json()
-        assert len(response_json) == 2, response_json
-        assert service_id in response_json, response_json
-        assert response_json[service_id].get("status") == "up", response_json
+        data = response.json()
+        assert len(data) == 2, str(data)
+        assert service_id in data, str(data)
+        assert data[service_id].get("status") == "up", str(data)
 
         # make sure OXPs have the new EVCs
         ## -> ampath
@@ -149,7 +150,7 @@ class TestE2EL2VPN:
         for evc in evcs.values():
             if evc.get("uni_a", {}).get("tag", {}).get("value") == 100:
                 found += 1
-        assert found == 0, evcs
+        assert found == 0, str(evcs)
         ## -> tenet
         response = requests.get("http://tenet:8181/api/kytos/mef_eline/v2/evc/")
         evcs = response.json()
@@ -157,7 +158,7 @@ class TestE2EL2VPN:
         for evc in evcs.values():
             if evc.get("uni_z", {}).get("tag", {}).get("value") == 100:
                 found += 1
-        assert found == 0, evcs
+        assert found == 0, str(evcs)
 
         # wait a few seconds to allow status change from UNDER_PROVISIONG to UP
         time.sleep(5)
@@ -204,7 +205,7 @@ class TestE2EL2VPN:
         for evc in evcs.values():
             if evc.get("uni_a", {}).get("tag", {}).get("value") == 100:
                 found += 1
-        assert found == 1, evcs
+        assert found == 1, str(evcs)
         ## -> tenet
         response = requests.get("http://tenet:8181/api/kytos/mef_eline/v2/evc/")
         evcs = response.json()
@@ -212,7 +213,7 @@ class TestE2EL2VPN:
         for evc in evcs.values():
             if evc.get("uni_z", {}).get("tag", {}).get("value") == 100:
                 found += 1
-        assert found == 1, evcs
+        assert found == 1, str(evcs)
 
     def test_045_edit_port_l2vpn_successfully(self):
         """Test change the port_id of endpoints of an existing L2vpn connection."""
@@ -221,10 +222,8 @@ class TestE2EL2VPN:
         data = response.json()
         key = list(data.keys())[0]
         current_data = data[key]  
-        assert current_data["endpoints"][0]["port_id"] in ["urn:sdx:port:tenet.ac.za:Tenet03:50", \
-                                                           "urn:sdx:port:ampath.net:Ampath3:50"], str(data)
-        assert current_data["endpoints"][1]["port_id"] in ["urn:sdx:port:tenet.ac.za:Tenet03:50", \
-                                                           "urn:sdx:port:ampath.net:Ampath3:50"], str(data)
+        assert current_data["endpoints"][0]["port_id"] == "urn:sdx:port:ampath.net:Ampath3:50", str(data)
+        assert current_data["endpoints"][1]["port_id"] == "urn:sdx:port:tenet.ac.za:Tenet03:50", str(data)
 
         # Change port_id
         payload = {

--- a/tests/test_06_l2vpn_return_codes.py
+++ b/tests/test_06_l2vpn_return_codes.py
@@ -71,6 +71,39 @@ class TestE2EReturnCodes:
         }
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
+        service_id = response.json()["service_id"]
+
+        # allow time for SDX-Controller propagate changes
+        time.sleep(5)
+
+        response = requests.get(f"{api_url}/{service_id}")
+        assert response.status_code == 200, response.text
+        data = response.json()[service_id]
+        assert data["status"] == "up", str(data)
+        assert len(data["endpoints"]) == 2, str(data)
+        assert len(data["current_path"]) > 0, str(data)
+        service_id = response.json()["service_id"]
+
+        # allow time for SDX-Controller propagate changes
+        time.sleep(5)
+
+        response = requests.get(f"{api_url}/{service_id}")
+        assert response.status_code == 200, response.text
+        data = response.json()[service_id]
+        assert data["status"] == "up", str(data)
+        assert len(data["endpoints"]) == 2, str(data)
+        assert len(data["current_path"]) > 0, str(data)
+        service_id = response.json()["service_id"]
+
+        # allow time for SDX-Controller propagate changes
+        time.sleep(5)
+
+        response = requests.get(f"{api_url}/{service_id}")
+        assert response.status_code == 200, response.text
+        data = response.json()[service_id]
+        assert data["status"] == "up", str(data)
+        assert len(data["endpoints"]) == 2, str(data)
+        assert len(data["current_path"]) > 0, str(data)
 
     def test_012_create_l2vpn_with_vlan_any(self):
         """
@@ -534,6 +567,9 @@ class TestE2EReturnCodes:
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
 
+        # allow time for SDX-Controller to propagate changes
+        time.sleep(5)
+
         payload = {
             "name": "Test L2VPN creation available bw",
             "endpoints": [
@@ -570,6 +606,9 @@ class TestE2EReturnCodes:
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
 
+        # allow time for SDX-Controller to propagate changes
+        time.sleep(5)
+
         payload = {
             "name": "Test L2VPN creation no available bw",
             "endpoints": [
@@ -584,6 +623,18 @@ class TestE2EReturnCodes:
         }
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
+
+        # allow time for SDX-Controller to propagate changes
+        time.sleep(5)
+
+        response = requests.get(api_url)
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert len(data) == 2, str(data)
+        for service_id, l2vpn in data.items():
+            assert l2vpn["status"] == "up", str(l2vpn)
+            assert len(l2vpn["endpoints"]) == 2, str(l2vpn)
+            assert len(l2vpn["current_path"]) > 0, str(l2vpn)
 
     def test_055_create_l2vpn_with_valid_max_delay(self):
         """
@@ -604,6 +655,18 @@ class TestE2EReturnCodes:
         }
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
+
+        # allow time for SDX-Controller to propagate changes
+        time.sleep(5)
+
+        response = requests.get(api_url)
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert len(data) == 1, str(data)
+        for service_id, l2vpn in data.items():
+            assert l2vpn["status"] == "up", str(l2vpn)
+            assert len(l2vpn["endpoints"]) == 2, str(l2vpn)
+            assert len(l2vpn["current_path"]) > 0, str(l2vpn)
 
     def test_056_create_l2vpn_with_max_delay_out_of_range(self):
         """
@@ -667,6 +730,18 @@ class TestE2EReturnCodes:
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
 
+        # allow time for SDX-Controller to propagate changes
+        time.sleep(5)
+
+        response = requests.get(api_url)
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert len(data) == 1, str(data)
+        for service_id, l2vpn in data.items():
+            assert l2vpn["status"] == "up", str(l2vpn)
+            assert len(l2vpn["endpoints"]) == 2, str(l2vpn)
+            assert len(l2vpn["current_path"]) > 0, str(l2vpn)
+
     def test_059_create_l2vpn_with_max_number_oxps_out_of_range(self):
         """
         Test the return code for creating a SDX L2VPN
@@ -728,6 +803,9 @@ class TestE2EReturnCodes:
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
 
+        # allow time for SDX-Controller to propagate changes
+        time.sleep(5)
+
         payload = {
             "name": "Test L2VPN creation",
             "endpoints": [
@@ -764,6 +842,9 @@ class TestE2EReturnCodes:
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
 
+        # allow time for SDX-Controller to propagate changes
+        time.sleep(5)
+
         payload = {
             "name": "Test L2VPN creation no available oxps",
             "endpoints": [
@@ -778,6 +859,18 @@ class TestE2EReturnCodes:
         }
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
+
+        # allow time for SDX-Controller to propagate changes
+        time.sleep(5)
+
+        response = requests.get(api_url)
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert len(data) == 2, str(data)
+        for service_id, l2vpn in data.items():
+            assert l2vpn["status"] == "up", str(l2vpn)
+            assert len(l2vpn["endpoints"]) == 2, str(l2vpn)
+            assert len(l2vpn["current_path"]) > 0, str(l2vpn)
 
     def test_070_create_l2vpn_with_impossible_scheduling(self):
         """

--- a/tests/test_06_l2vpn_return_codes.py
+++ b/tests/test_06_l2vpn_return_codes.py
@@ -65,7 +65,6 @@ class TestE2EReturnCodes:
         assert data["status"] == "up", str(data)
         assert len(data["endpoints"]) == 2, str(data)
         assert len(data["current_path"]) > 0, str(data)
-        service_id = response.json()["service_id"]
     
     def test_011_create_l2vpn_vlan_translation(self):
         """
@@ -94,7 +93,6 @@ class TestE2EReturnCodes:
         assert data["status"] == "up", str(data)
         assert len(data["endpoints"]) == 2, str(data)
         assert len(data["current_path"]) > 0, str(data)
-        service_id = response.json()["service_id"]
 
         # allow time for SDX-Controller propagate changes
         time.sleep(5)
@@ -105,7 +103,6 @@ class TestE2EReturnCodes:
         assert data["status"] == "up", str(data)
         assert len(data["endpoints"]) == 2, str(data)
         assert len(data["current_path"]) > 0, str(data)
-        service_id = response.json()["service_id"]
 
         # allow time for SDX-Controller propagate changes
         time.sleep(5)

--- a/tests/test_06_l2vpn_return_codes.py
+++ b/tests/test_06_l2vpn_return_codes.py
@@ -130,6 +130,17 @@ class TestE2EReturnCodes:
         }
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
+        service_id = response.json()["service_id"]
+
+        # allow time for SDX-Controller propagate changes
+        time.sleep(5)
+
+        response = requests.get(f"{api_url}/{service_id}")
+        assert response.status_code == 200, response.text
+        data = response.json()[service_id]
+        assert data["status"] == "up", str(data)
+        assert len(data["endpoints"]) == 2, str(data)
+        assert len(data["current_path"]) > 0, str(data)
     
     def test_013_create_l2vpn_with_vlan_range(self):
         """
@@ -482,7 +493,7 @@ class TestE2EReturnCodes:
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
 
-        time.sleep(30)
+        time.sleep(5)
 
         response = requests.post(api_url, json=payload)
         assert response.status_code == 409, response.text
@@ -506,6 +517,17 @@ class TestE2EReturnCodes:
         }
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
+        service_id = response.json()["service_id"]
+
+        # give enough time to SDX-Controller to propagate change to OXPs
+        time.sleep(5)
+
+        response = requests.get(api_url)
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert len(data) == 1, str(data)
+        assert service_id in data, str(data)
+        assert data[service_id].get("status") == "up", str(data)
 
     def test_051_create_l2vpn_with_min_bw_out_of_range(self):
         """

--- a/tests/test_06_l2vpn_return_codes.py
+++ b/tests/test_06_l2vpn_return_codes.py
@@ -54,6 +54,18 @@ class TestE2EReturnCodes:
         }
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
+        service_id = response.json()["service_id"]
+
+        # allow time for SDX-Controller propagate changes
+        time.sleep(5)
+
+        response = requests.get(f"{api_url}/{service_id}")
+        assert response.status_code == 200, response.text
+        data = response.json()[service_id]
+        assert data["status"] == "up", str(data)
+        assert len(data["endpoints"]) == 2, str(data)
+        assert len(data["current_path"]) > 0, str(data)
+        service_id = response.json()["service_id"]
     
     def test_011_create_l2vpn_vlan_translation(self):
         """

--- a/tests/test_06_l2vpn_return_codes.py
+++ b/tests/test_06_l2vpn_return_codes.py
@@ -148,9 +148,9 @@ class TestE2EReturnCodes:
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
         data = response.json()
-        assert data.get("status") == "under provisioning", data
+        assert data.get("status") == "under provisioning", str(data)
         service_id = data.get("service_id")
-        assert service_id != None, data
+        assert service_id != None, str(data)
 
         # give enough time to SDX-Controller to propagate change to OXPs
         time.sleep(5)
@@ -158,9 +158,9 @@ class TestE2EReturnCodes:
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
         data = response.json()
-        assert len(data) == 1, data
-        assert service_id in data, data
-        assert data[service_id].get("status") == "up", data
+        assert len(data) == 1, str(data)
+        assert service_id in data, str(data)
+        assert data[service_id].get("status") == "up", str(data)
 
         #
         # make sure OXPs have the new EVCs
@@ -172,7 +172,7 @@ class TestE2EReturnCodes:
         for evc in evcs.values():
             if evc.get("uni_a", {}).get("tag", {}).get("value") == [[600, 999]]:
                 found += 1
-        assert found == 1, evcs
+        assert found == 1, str(evcs)
         ## -> sax
         response = requests.get("http://sax:8181/api/kytos/mef_eline/v2/evc/")
         evcs = response.json()
@@ -181,7 +181,7 @@ class TestE2EReturnCodes:
         for evc in evcs.values():
             if evc.get("uni_z", {}).get("tag", {}).get("value") == [[600, 999]]:
                 found += 1
-        assert found == 1, evcs
+        assert found == 1, str(evcs)
 
     def test_014_create_l2vpn_with_vlan_untagged(self):
         """
@@ -200,9 +200,9 @@ class TestE2EReturnCodes:
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
         data = response.json()
-        assert data.get("status") == "under provisioning", data
+        assert data.get("status") == "under provisioning", str(data)
         service_id = data.get("service_id")
-        assert service_id != None, data
+        assert service_id != None, str(data)
 
         # give enough time to SDX-Controller to propagate change to OXPs
         time.sleep(5)
@@ -210,9 +210,9 @@ class TestE2EReturnCodes:
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
         data = response.json()
-        assert len(data) == 1, data
-        assert service_id in data, data
-        assert data[service_id].get("status") == "up", data
+        assert len(data) == 1, str(data)
+        assert service_id in data, str(data)
+        assert data[service_id].get("status") == "up", str(data)
 
         #
         # make sure OXPs have the new EVCs
@@ -224,7 +224,7 @@ class TestE2EReturnCodes:
         for evc in evcs.values():
             if evc.get("uni_a", {}).get("tag", {}).get("value") == 599:
                 found += 1
-        assert found == 1, evcs
+        assert found == 1, str(evcs)
         ## -> sax
         response = requests.get("http://sax:8181/api/kytos/mef_eline/v2/evc/")
         evcs = response.json()
@@ -237,7 +237,7 @@ class TestE2EReturnCodes:
         for evc in evcs.values():
             if evc.get("uni_z", {}).get("tag", {}).get("value") == "untagged":
                 found += 1
-        assert found == 1, evcs
+        assert found == 1, str(evcs)
 
     def _future_date(self, isoformat_time=True):
         # Get the current time

--- a/tests/test_07_l2vpn_return_codes.py
+++ b/tests/test_07_l2vpn_return_codes.py
@@ -70,6 +70,18 @@ class TestE2EReturnCodesEditL2vpn:
         response = requests.patch(f"{api_url}/{self.key}", json=self.payload)
         assert response.status_code == 201, response.text
 
+        # allow time for SDX-Controller to propagate changes
+        time.sleep(5)
+
+        response = requests.get(api_url)
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert len(data) == 1, str(data)
+        for service_id, l2vpn in data.items():
+            assert l2vpn["status"] == "up", str(l2vpn)
+            assert len(l2vpn["endpoints"]) == 2, str(l2vpn)
+            assert len(l2vpn["current_path"]) > 0, str(l2vpn)
+
     def test_011_edit_l2vpn_port_id(self):
         """
         Test the return code for editing a SDX L2VPN
@@ -80,6 +92,18 @@ class TestE2EReturnCodesEditL2vpn:
         self.payload['endpoints'][0]['port_id'] = "urn:sdx:port:sax.net:Sax01:50"
         response = requests.patch(f"{api_url}/{self.key}", json=self.payload)
         assert response.status_code == 201, response.text
+
+        # allow time for SDX-Controller to propagate changes
+        time.sleep(5)
+
+        response = requests.get(api_url)
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert len(data) == 1, str(data)
+        for service_id, l2vpn in data.items():
+            assert l2vpn["status"] == "up", str(l2vpn)
+            assert len(l2vpn["endpoints"]) == 2, str(l2vpn)
+            assert len(l2vpn["current_path"]) > 0, str(l2vpn)
 
     def test_020_edit_l2vpn_with_vlan_integer(self):
         """
@@ -254,6 +278,18 @@ class TestE2EReturnCodesEditL2vpn:
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
 
+        # allow time for SDX-Controller to propagate changes
+        time.sleep(5)
+
+        response = requests.get(api_url)
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert len(data) == 2, str(data)
+        for service_id, l2vpn in data.items():
+            assert l2vpn["status"] == "up", str(l2vpn)
+            assert len(l2vpn["endpoints"]) == 2, str(l2vpn)
+            assert len(l2vpn["current_path"]) > 0, str(l2vpn)
+
         # Edit the first l2pvn to match the newly created one
         self.payload['endpoints'][0]['vlan'] = "500"
         self.payload['endpoints'][1]['vlan'] = "500"
@@ -281,6 +317,18 @@ class TestE2EReturnCodesEditL2vpn:
         response = requests.patch(f"{api_url}/{self.key}", json=payload)
         assert response.status_code == 201, response.text
 
+        # allow time for SDX-Controller to propagate changes
+        time.sleep(5)
+
+        response = requests.get(api_url)
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert len(data) == 1, str(data)
+        for service_id, l2vpn in data.items():
+            assert l2vpn["status"] == "up", str(l2vpn)
+            assert len(l2vpn["endpoints"]) == 2, str(l2vpn)
+            assert len(l2vpn["current_path"]) > 0, str(l2vpn)
+
     def test_061_edit_l2vpn_with_max_delay(self):
         """
         Test the return code for editing a SDX L2VPN
@@ -302,6 +350,18 @@ class TestE2EReturnCodesEditL2vpn:
         response = requests.patch(f"{api_url}/{self.key}", json=payload)
         assert response.status_code == 201, response.text
 
+        # allow time for SDX-Controller to propagate changes
+        time.sleep(5)
+
+        response = requests.get(api_url)
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert len(data) == 1, str(data)
+        for service_id, l2vpn in data.items():
+            assert l2vpn["status"] == "up", str(l2vpn)
+            assert len(l2vpn["endpoints"]) == 2, str(l2vpn)
+            assert len(l2vpn["current_path"]) > 0, str(l2vpn)
+
     def test_062_edit_l2vpn_with_max_number_oxps(self):
         """
         Test the return code for editing a SDX L2VPN
@@ -322,6 +382,18 @@ class TestE2EReturnCodesEditL2vpn:
         }
         response = requests.patch(f"{api_url}/{self.key}", json=payload)
         assert response.status_code == 201, response.text
+
+        # allow time for SDX-Controller to propagate changes
+        time.sleep(5)
+
+        response = requests.get(api_url)
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert len(data) == 1, str(data)
+        for service_id, l2vpn in data.items():
+            assert l2vpn["status"] == "up", str(l2vpn)
+            assert len(l2vpn["endpoints"]) == 2, str(l2vpn)
+            assert len(l2vpn["current_path"]) > 0, str(l2vpn)
 
     def test_063_edit_l2vpn_with_min_bw_out_of_range(self):
         """
@@ -409,6 +481,18 @@ class TestE2EReturnCodesEditL2vpn:
         }
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
+
+        # allow time for SDX-Controller to propagate changes
+        time.sleep(5)
+
+        response = requests.get(api_url)
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert len(data) == 2, str(data)
+        for service_id, l2vpn in data.items():
+            assert l2vpn["status"] == "up", str(l2vpn)
+            assert len(l2vpn["endpoints"]) == 2, str(l2vpn)
+            assert len(l2vpn["current_path"]) > 0, str(l2vpn)
 
         # Edit high min_bw to get code 410
         payload = {


### PR DESCRIPTION
Fix #85 

### Description of the change

- Added `time.sleep` into critical points were we need to wait the Controller to finish some processing before running the next step (ex: wait for the L2VPN to be UP before deleting it).
- Enhance test `tests/test_05_l2vpn.py::test_045_edit_port_l2vpn_successfully` to use UNI ports when changing the endpoints, because using a NNI as the endpoint is currently not supported (https://github.com/atlanticwave-sdx/sdx-controller/issues/472)
- Added more validations (asserts) to properly check the results of each test

### Local tests

I've executed the end-to-end tests 10 times on two different systems to validate the stability with the changes:

```
$ git status
On branch fix/85_flaky_various_tests
Your branch is up to date with 'origin/fix/85_flaky_various_tests'.
...
$ (for i in $(seq 10); do echo $i -- $(date); docker compose down -v; docker compose up -d; ./wait-mininet-ready.sh; docker compose exec -it mininet python3 -m pytest tests/; done) | tee result-e2e.log
$ grep passed result-e2e.log
================== 79 passed, 2 xfailed in 1273.85s (0:21:13) ==================
================== 79 passed, 2 xfailed in 1290.63s (0:21:30) ==================
================== 79 passed, 2 xfailed in 1299.53s (0:21:39) ==================
================== 79 passed, 2 xfailed in 1284.17s (0:21:24) ==================
================== 79 passed, 2 xfailed in 1285.15s (0:21:25) ==================
================== 79 passed, 2 xfailed in 1259.46s (0:20:59) ==================
================== 79 passed, 2 xfailed in 1275.43s (0:21:15) ==================
================== 79 passed, 2 xfailed in 1281.89s (0:21:21) ==================
================== 79 passed, 2 xfailed in 1292.90s (0:21:32) ==================
================== 79 passed, 2 xfailed in 1289.99s (0:21:29) ==================
```

And also:

```
$ (for i in $(seq 10); do echo $i -- $(date); docker compose down -v; docker compose up -d; ./wait-mininet-ready.sh; docker compose exec -it mininet python3 -m pytest tests/; done) | tee result-e2e.log
$ grep passed result-e2e.log
================== 79 passed, 2 xfailed in 1279.91s (0:21:19) ==================
================== 79 passed, 2 xfailed in 1280.52s (0:21:20) ==================
================== 79 passed, 2 xfailed in 1281.08s (0:21:21) ==================
================== 79 passed, 2 xfailed in 1280.97s (0:21:20) ==================
================== 79 passed, 2 xfailed in 1280.00s (0:21:20) ==================
================== 79 passed, 2 xfailed in 1280.22s (0:21:20) ==================
================== 79 passed, 2 xfailed in 1280.49s (0:21:20) ==================
================== 79 passed, 2 xfailed in 1284.49s (0:21:24) ==================
================== 79 passed, 2 xfailed in 1271.18s (0:21:11) ==================
================== 79 passed, 2 xfailed in 1279.82s (0:21:19) ==================
```