### PR TITLE
Improvements on test files 05 and 06 to avoid flaky tests

### DIFF
--- a/tests/test_05_l2vpn.py
+++ b/tests/test_05_l2vpn.py
@@ -516,3 +516,18 @@ class TestE2EL2VPN:
                 ping_result = hostA.cmd(f"ping6 -c4 -i0.2 2001:db8:ffff:{vlan_id}::2")
                 assert ', 0% packet loss,' in ping_result, f"{vlan_id=} {dataA=} {dataZ=} {ping_result=}"
             vlan_inc += 1
+
+        api_url = SDX_CONTROLLER + '/l2vpn/1.0'
+        data = requests.get(api_url).json()
+        assert len(data) == 15, str(data)
+
+        # Delete all L2VPN
+        for key in data:
+            response = requests.delete(f"{api_url}/{key}")
+            assert response.status_code == 200, response.text
+
+        time.sleep(3)
+
+        api_url = SDX_CONTROLLER + '/l2vpn/1.0'
+        data = requests.get(api_url).json()
+        assert len(data) == 0, str(data)

--- a/tests/test_06_l2vpn_return_codes.py
+++ b/tests/test_06_l2vpn_return_codes.py
@@ -33,6 +33,7 @@ class TestE2EReturnCodes:
         response_json = response.json()
         for l2vpn in response_json:
             response = requests.delete(api_url+f'/{l2vpn}')
+            assert response.status_code == 200, response.text
 
         # wait for L2VPN to be actually deleted
         time.sleep(2)


### PR DESCRIPTION
This PR adds some extra checks when removing L2VPNs on test_06 and also removes the created L2VPN from test05::test_070_multiple_l2vpn_with_bandwidth_qos_metric to avoid conflicting with other ones.