### PR TITLE
New test for use case 6

### DIFF
--- a/tests/test_20_use_case_topology.py
+++ b/tests/test_20_use_case_topology.py
@@ -466,7 +466,7 @@ class TestE2ETopologyUseCases:
         assert response.status_code == 200, response.text
         l2vpn_response = response.json()
         assert l2vpn_id in l2vpn_response
-        assert l2vpn_response.get(l2vpn_id).get("status") == "down", "L2VPN status should be down after UNI port goes down"
+        assert l2vpn_response.get(l2vpn_id).get("status") == "down", str(l2vpn_response)
 
         # Simulate UNI port coming back up
         ampath_node.intf('Ampath1-eth50').ifconfig('up')
@@ -477,5 +477,5 @@ class TestE2ETopologyUseCases:
         response = requests.get(API_URL)
         assert response.status_code == 200, response.text
         l2vpn_response = response.json()
-        assert l2vpn_response.get(l2vpn_id).get("status") == "up", "L2VPN status should be up after UNI port comes back up"
+        assert l2vpn_response.get(l2vpn_id).get("status") == "up", str(l2vpn_response)
         assert ', 0% packet loss,' in l2vpn_data['h'].cmd(l2vpn_data['ping_str'])


### PR DESCRIPTION
Use Case 6: OXPO sends a topology update with a Port UP and that port is UNI for some L2VPNs.

Expected behavior: SDX Controller: update the statuses involved. Use Case 3 is explicit saying the configs should not be removed in case of a Port Down which means the data plane config is already there.