### PR TITLE
New test for use case 8

### DIFF
--- a/tests/test_20_use_case_topology.py
+++ b/tests/test_20_use_case_topology.py
@@ -415,7 +415,7 @@ class TestE2ETopologyUseCases:
         activate the L2VPNs. If the port is just an addition (a new inter-domain path), do nothing. 
         """
         
-        l2vpn_data = self.create_new_l2vpn(vlan='700',node2='Tenet03')
+        l2vpn_data = self.create_new_l2vpn(vlan='500',node2='Tenet03')
         l2vpn_id = l2vpn_data['id']
 
         # Bring down a inter-domain port to simulate a scenario where L2VPNs might be down
@@ -452,7 +452,7 @@ class TestE2ETopologyUseCases:
         which means the data plane config is already there.
         """
         
-        l2vpn_data = self.create_new_l2vpn(vlan='800')
+        l2vpn_data = self.create_new_l2vpn(vlan='600')
         l2vpn_id = l2vpn_data['id']
 
         # Simulate UNI port going down
@@ -500,7 +500,7 @@ class TestE2ETopologyUseCases:
         time.sleep(10)
 
         # Create a L2VPN that is not associated with the port
-        l2vpn_data = self.create_new_l2vpn(vlan='800')
+        l2vpn_data = self.create_new_l2vpn(vlan='700')
         l2vpn_id = l2vpn_data['id']
 
         path_ports = [p['port_id'] for p in l2vpn_data['data']['current_path']]
@@ -525,7 +525,6 @@ class TestE2ETopologyUseCases:
         3. L2VPN status changes to down due to no alternate path exists,
         4. the Link is not exported by the OXP and SDX-LC,
         """
-        link_name = 'urn:sdx:link:tenet.ac.za:Tenet01/2_Tenet03/2'
         endp1 = 'Tenet01-eth2'
         endp2 = 'Tenet03-eth2'
 
@@ -537,14 +536,15 @@ class TestE2ETopologyUseCases:
         data = response.json()
         link_id = None
         for key, value in data['links'].items():
-            link_id = key
             endpoint_a = value["endpoint_a"]["name"]
             endpoint_b = value["endpoint_b"]["name"]
             if set([endpoint_a, endpoint_b]) == set([endp1, endp2]):
+               link_name = 'urn:sdx:link:tenet.ac.za:Tenet01/2_Tenet03/2'
+               link_id = key
                break
         assert link_id
 
-        l2vpn_data = self.create_new_l2vpn(vlan='900', node1='Tenet01', node2='Tenet03')
+        l2vpn_data = self.create_new_l2vpn(vlan='800', node1='Tenet01', node2='Tenet03')
         l2vpn_id = l2vpn_data['id']
 
         # Get initial topology version
@@ -604,8 +604,6 @@ class TestE2ETopologyUseCases:
         """
         Use case 8: Test Remove Link (because it was deleted by the OXP)
         """
-        
-        link_name = 'urn:sdx:link:tenet.ac.za:Tenet01/1_Tenet02/1'
         endp1 = 'Tenet01-eth1'
         endp2 = 'Tenet02-eth1'
 
@@ -617,14 +615,15 @@ class TestE2ETopologyUseCases:
         data = response.json()
         link_id = None
         for key, value in data['links'].items():
-            link_id = key
             endpoint_a = value["endpoint_a"]["name"]
             endpoint_b = value["endpoint_b"]["name"]
             if set([endpoint_a, endpoint_b]) == set([endp1, endp2]):
-               break
+                link_id = key
+                link_name = 'urn:sdx:link:tenet.ac.za:Tenet01/1_Tenet02/1'
+                break
         assert link_id
 
-        l2vpn_data = self.create_new_l2vpn(vlan='1000', node1='Tenet01', node2='Tenet02')
+        l2vpn_data = self.create_new_l2vpn(vlan='810', node1='Tenet01', node2='Tenet02')
         l2vpn_id = l2vpn_data['id']
 
         # Get initial topology version

--- a/tests/test_20_use_case_topology.py
+++ b/tests/test_20_use_case_topology.py
@@ -514,3 +514,149 @@ class TestE2ETopologyUseCases:
         # Verify no L2VPN was created or modified
         final_data = requests.get(API_URL).json()
         assert final_data[l2vpn_id] == l2vpn_data['data'], "L2VPN state changed unexpectedly"
+
+    @pytest.mark.xfail(reason="L2VPN remains up after a link is removed from topology and no alternate path exists")
+    def test_080_link_missing(self):
+        """
+        Use case 8: Test Remove Link (because it was deleted by the OXP)
+
+        1. Topology version number increases, 
+        2. link is removed from topology,
+        3. L2VPN status changes to down due to no alternate path exists,
+        4. the Link is not exported by the OXP and SDX-LC,
+        """
+        link_name = 'urn:sdx:link:tenet.ac.za:Tenet01/2_Tenet03/2'
+        endp1 = 'Tenet01-eth2'
+        endp2 = 'Tenet03-eth2'
+
+        # Get link id
+        tenet_api = KYTOS_API % 'tenet'
+        api_url_tenet = f'{tenet_api}/topology/v3/links'
+        response = requests.get(api_url_tenet)
+        assert response.status_code == 200
+        data = response.json()
+        link_id = None
+        for key, value in data['links'].items():
+            link_id = key
+            endpoint_a = value["endpoint_a"]["name"]
+            endpoint_b = value["endpoint_b"]["name"]
+            if set([endpoint_a, endpoint_b]) == set([endp1, endp2]):
+               break
+        assert link_id
+
+        l2vpn_data = self.create_new_l2vpn(vlan='900', node1='Tenet01', node2='Tenet03')
+        l2vpn_id = l2vpn_data['id']
+
+        # Get initial topology version
+        initial_topology = requests.get(API_URL_TOPO).json()
+        initial_version = float(initial_topology["version"])
+        links = {link["id"] for link in initial_topology["links"]}
+        assert link_name in links
+
+        # Disabling link
+        self.net.net.configLinkStatus('Tenet01', 'Tenet03', 'down')
+        api_url_disable = f'{api_url_tenet}/{link_id}/disable'
+        response = requests.post(api_url_disable)
+        assert response.status_code == 201, response.text
+    
+        # Deleting link
+        api_url = f'{api_url_tenet}/{link_id}'
+        response = requests.delete(api_url)
+        assert response.status_code == 200, response.text
+            
+        time.sleep(15) 
+    
+        # Verify topology version increased
+        updated_topology = requests.get(API_URL_TOPO).json()
+        updated_version = float(updated_topology["version"])
+        assert updated_version > initial_version, "Topology version did not increase"
+
+        links = {link["id"]: link for link in updated_topology["links"]}
+        assert link_name not in links 
+
+        # Verify L2VPN status is down (no alternate path)
+        response = requests.get(API_URL)
+        assert response.status_code == 200, response.text
+        l2vpn_response = response.json()
+        l2vpn_status = l2vpn_response.get(l2vpn_id).get("status")
+        assert l2vpn_status == "down", f"L2VPN status should be down, but is {l2vpn_status}"
+
+        # Test connectivity (should fail)
+        assert ', 100% packet loss,' in l2vpn_data['host1'].cmd(l2vpn_data['ping_str'])
+
+        # Verify Link is not exported by tenet and SDX-LC
+        response = requests.get(f'{tenet_api}/topology/v3/links')
+        assert response.status_code == 200
+        data = response.json()
+        for _, link in data['links'].items():
+            ep_a = link['endpoint_a']['name']
+            ep_b = link['endpoint_b']['name']
+            assert set(['Tenet01', 'Tenet03']) != set([ep_a, ep_b]), link
+
+        sdx_api = KYTOS_SDX_API % 'tenet'
+        response = requests.get(f"{sdx_api}/topology/2.0.0")
+        assert response.status_code == 200
+        data = response.json()
+        links = [link['id'] for link in data['links']]
+        assert link_name not in links
+        
+    def test_081_link_missing_with_alternate_path(self):
+        """
+        Use case 8: Test Remove Link (because it was deleted by the OXP)
+        """
+        
+        link_name = 'urn:sdx:link:tenet.ac.za:Tenet01/1_Tenet02/1'
+        endp1 = 'Tenet01-eth1'
+        endp2 = 'Tenet02-eth1'
+
+        # Get link id
+        tenet_api = KYTOS_API % 'tenet'
+        api_url_tenet = f'{tenet_api}/topology/v3/links'
+        response = requests.get(api_url_tenet)
+        assert response.status_code == 200
+        data = response.json()
+        link_id = None
+        for key, value in data['links'].items():
+            link_id = key
+            endpoint_a = value["endpoint_a"]["name"]
+            endpoint_b = value["endpoint_b"]["name"]
+            if set([endpoint_a, endpoint_b]) == set([endp1, endp2]):
+               break
+        assert link_id
+
+        l2vpn_data = self.create_new_l2vpn(vlan='1000', node1='Tenet01', node2='Tenet02')
+        l2vpn_id = l2vpn_data['id']
+
+        # Get initial topology version
+        initial_topology = requests.get(API_URL_TOPO).json()
+        initial_version = float(initial_topology["version"])
+        links = {link["id"] for link in initial_topology["links"]}
+        assert link_name in links
+
+        # Disabling link
+        self.net.net.configLinkStatus('Tenet01', 'Tenet02', 'down')
+        api_url_disable = f'{api_url_tenet}/{link_id}/disable'
+        response = requests.post(api_url_disable)
+        assert response.status_code == 201, response.text
+    
+        # Deleting link
+        api_url = f'{api_url_tenet}/{link_id}'
+        response = requests.delete(api_url)
+        assert response.status_code == 200, response.text
+            
+        time.sleep(15) 
+    
+        # Verify topology version increased
+        updated_topology = requests.get(API_URL_TOPO).json()
+        updated_version = float(updated_topology["version"])
+        assert updated_version > initial_version, "Topology version did not increase"
+
+        links = {link["id"]: link for link in updated_topology["links"]}
+        assert link_name not in links 
+
+        # Verify L2VPN status is down (alternate path)
+        response = requests.get(API_URL)
+        assert response.status_code == 200, response.text
+        l2vpn_response = response.json()
+        l2vpn_status = l2vpn_response.get(l2vpn_id).get("status")
+        assert l2vpn_status == "up", f"L2VPN status should be up, but is {l2vpn_status}"


### PR DESCRIPTION
Use case 8: Test Remove Link (because it was deleted by the OXP)

        1. Topology version number increases, 
        2. link is removed from topology,
        3. L2VPN status changes to down due to no alternate path exists,
        4. the Link is not exported by the OXP and SDX-LC,