### PR TITLE
Test for use case 12

### DIFF
--- a/tests/test_20_use_case_topology.py
+++ b/tests/test_20_use_case_topology.py
@@ -714,4 +714,53 @@ class TestE2ETopologyUseCases:
         l2vpn_response = response.json()
         assert l2vpn_response.get(l2vpn_id).get("status") == "down", "L2VPN status should be down/error due to unsupported service"
         assert ', 100% packet loss,' in l2vpn_data['h'].cmd(l2vpn_data['ping_str'])
-        
+      
+    def test_120_l2vpn_provisioning_failure_breakdown(self):
+        """
+        Use Case 12: L2VPN provisioning request generated a breakdown to all OXPs involved. 
+        """
+
+        l2vpn_payload = {
+            "name": "Test L2VPN for partial provisioning failure",
+            "endpoints": [
+                {
+                    "port_id": "urn:sdx:port:ampath.net:Tenet01:50",
+                    "vlan": "1200",
+                },
+                {
+                    "port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50",
+                    "vlan": "1200",
+                }
+            ]
+        }
+
+        # To simulate partial failure in E2E tests, we can only test the scenario where
+        # the SDX Controller handles a complete failure or success.
+        # A full simulation of this UC would require more control over OXP behavior.
+        # For now, we'll test that a failed provisioning attempt does not leave zombie flows.
+
+        # Simulate a scenario where one OXP fails to provision (e.g., by making its port unavailable)
+        tenet_node = self.net.net.get('Tenet01')
+        tenet_node.intf('Tenet01-eth50').ifconfig('down')
+        time.sleep(15)
+
+        response = requests.post(API_URL, json=l2vpn_payload)
+        assert response.status_code != 201, "L2VPN provisioning should fail due to unavailable port"
+
+        # Bring the port back up
+        tenet_node.intf('Tenet01-eth50').ifconfig('up')
+        time.sleep(15)
+
+        # Verify that no L2VPN was created (or it was cleaned up if partially created)
+        response = requests.get(API_URL)
+        assert response.status_code == 200, response.text
+        l2vpn_data = response.json()
+        # Check if the L2VPN with the specific name exists and its status
+        found_l2vpn = False
+        for l2vpn_id, l2vpn_info in l2vpn_data.items():
+            if l2vpn_info.get("name") == "Test L2VPN for partial provisioning failure":
+                found_l2vpn = True
+                assert l2vpn_info.get("status") == "down" or l2vpn_info.get("status") == "error", "L2VPN should be in down/error state or not exist"
+                break
+        assert not found_l2vpn, "L2VPN should not be successfully provisioned or should be cleaned up"
+      


### PR DESCRIPTION
Use Case 12: L2VPN provisioning request generated a breakdown to all OXPs involved. 
       
To simulate partial failure in E2E tests, we can only test the scenario where the SDX Controller handles a complete failure or success.
A full simulation of this use case would require more control over OXP behavior.
For now, we'll test that a failed provisioning attempt does not leave zombie flows.
