### PR TITLE
Use case 10: Removing a vlan range entry

### DIFF
--- a/tests/test_20_use_case_topology.py
+++ b/tests/test_20_use_case_topology.py
@@ -567,7 +567,7 @@ class TestE2ETopologyUseCases:
         l2vpn_response = response.json()
         l2vpn_response = l2vpn_response.get(l2vpn_id)
         assert l2vpn_response.get("status") == "error", l2vpn_response
-    
+
     @pytest.mark.xfail(reason="The L2VPN path associated with VLAN 1070 remains unchanged after modifying the VLAN range to [100–200]")
     def test_107_removing_vlan_nni_with_alternate_path(self):
         """

--- a/tests/test_20_use_case_topology.py
+++ b/tests/test_20_use_case_topology.py
@@ -515,41 +515,21 @@ class TestE2ETopologyUseCases:
         final_data = requests.get(API_URL).json()
         assert final_data[l2vpn_id] == l2vpn_data['data'], "L2VPN state changed unexpectedly"
 
-    @pytest.mark.xfail(reason="The L2VPN with VLAN 1060 remains up even after modifying the VLAN range to [100–200]")
+    @pytest.mark.xfail(reason="The L2VPN with VLAN 1060 remains up even after removing the VLAN range")
     def test_106_removing_vlan_uni(self):
         """
         Use Case 10: OXPO sends a topology update with a changed VLAN range is for any of the services supported.
         """
         interfaces_id = 'aa:00:00:00:00:00:00:01:50'
-        interface_name = 'Ampath1-eth50'
         ampath_api = KYTOS_API % 'ampath'
         api_url_ampath = f'{ampath_api}/topology/v3'
-        payload = {
-            "sdx_vlan_range": [[100,200], [1000, 2000]]
-        }
-        response = requests.post(f"{api_url_ampath}/interfaces/{interfaces_id}/metadata", json=payload)
-        assert response.status_code == 201, response.text
-
-        # Force to send the topology to the SDX-LC
-        sdx_api = KYTOS_SDX_API % 'ampath'
-        response = requests.post(f"{sdx_api}/topology/2.0.0")
-        assert response.status_code == 200, response.text
-
-        time.sleep(15)
-
-        response = requests.get(API_URL_TOPO)
-        data = response.json()
-        for node in data['nodes']: 
-            for port in node['ports']:
-                if port['name'] == interface_name:
-                    assert port['services']['l2vpn_ptp']['vlan_range'] == [[100,200], [1000, 2000]], port
 
         l2vpn_data = self.create_new_l2vpn(vlan='1060')
         l2vpn_id = l2vpn_data['id']
 
         # Removing vlan
         payload = {
-            "sdx_vlan_range": [[1100, 1500]]
+            "sdx_vlan_range": []
         }
         response = requests.post(f"{api_url_ampath}/interfaces/{interfaces_id}/metadata", json=payload)
         assert response.status_code == 201, response.text
@@ -574,35 +554,15 @@ class TestE2ETopologyUseCases:
         """
 
         interfaces_id = 'aa:00:00:00:00:00:00:01:40'
-        interface_name = 'Ampath1-eth40'
         ampath_api = KYTOS_API % 'ampath'
         api_url_ampath = f'{ampath_api}/topology/v3'
-        payload = {
-            "sdx_vlan_range": [[100,200], [1000, 2000]]
-        }
-        response = requests.post(f"{api_url_ampath}/interfaces/{interfaces_id}/metadata", json=payload)
-        assert response.status_code == 201, response.text
-
-        # Force to send the topology to the SDX-LC
-        sdx_api = KYTOS_SDX_API % 'ampath'
-        response = requests.post(f"{sdx_api}/topology/2.0.0")
-        assert response.status_code == 200, response.text
-
-        time.sleep(15)
-
-        response = requests.get(API_URL_TOPO)
-        data = response.json()
-        for node in data['nodes']: 
-            for port in node['ports']:
-                if port['name'] == interface_name:
-                    assert port['services']['l2vpn_ptp']['vlan_range'] == [[100,200], [1000, 2000]], port
 
         l2vpn_data = self.create_new_l2vpn(vlan='1070')
         l2vpn_id = l2vpn_data['id']
 
         # Removing vlan
         payload = {
-            "sdx_vlan_range": [[1100, 1500]]
+            "sdx_vlan_range": []
         }
         response = requests.post(f"{api_url_ampath}/interfaces/{interfaces_id}/metadata", json=payload)
         assert response.status_code == 201, response.text

--- a/tests/test_20_use_case_topology.py
+++ b/tests/test_20_use_case_topology.py
@@ -578,10 +578,7 @@ class TestE2ETopologyUseCases:
         assert response.status_code == 200, response.text
         l2vpn_response = response.json()
         l2vpn_response = l2vpn_response.get(l2vpn_id)
-        assert l2vpn_response.get("status") == "up", l2vpn_response
-
-        current_path = '-'.join(['_'.join(n['port_id'].split(':')[-2:]) for n in l2vpn_response['current_path']])
-        assert 'Ampath1_40' not in current_path, current_path
+        assert l2vpn_response.get("status") == "error", l2vpn_response
 
     @pytest.mark.xfail(reason="EVCs from OXPs where L2VPN creation does not fail are not empty")
     def test_120_l2vpn_provisioning_failure(self):

--- a/tests/test_20_use_case_topology.py
+++ b/tests/test_20_use_case_topology.py
@@ -515,16 +515,115 @@ class TestE2ETopologyUseCases:
         final_data = requests.get(API_URL).json()
         assert final_data[l2vpn_id] == l2vpn_data['data'], "L2VPN state changed unexpectedly"
 
-    def test_100_vlan_range_change(self):
+    @pytest.mark.xfail(reason="The L2VPN with VLAN 1060 remains up even after modifying the VLAN range to [100–200]")
+    def test_106_removing_vlan_uni(self):
         """
         Use Case 10: OXPO sends a topology update with a changed VLAN range is for any of the services supported.
         """
-        
-    def test_110_service_no_longer_supported(self):
+
+        interfaces_id = 'aa:00:00:00:00:00:00:01:50'
+        interface_name = 'Ampath1-eth50'
+        ampath_api = KYTOS_API % 'ampath'
+        api_url_ampath = f'{ampath_api}/topology/v3'
+        payload = {
+        "sdx_vlan_range": [[100,200], [1000, 2000]]
+        }
+        response = requests.post(f"{api_url_ampath}/interfaces/{interfaces_id}/metadata", json=payload)
+        assert response.status_code == 201, response.text
+
+        # Force to send the topology to the SDX-LC
+        sdx_api = KYTOS_SDX_API % 'ampath'
+        response = requests.post(f"{sdx_api}/topology/2.0.0")
+        assert response.status_code == 200, response.text
+
+        time.sleep(15)
+
+        response = requests.get(API_URL_TOPO)
+        data = response.json()
+        for node in data['nodes']: 
+            for port in node['ports']:
+                if port['name'] == interface_name:
+                    assert port['services']['l2vpn_ptp']['vlan_range'] == [[100,200], [1000, 2000]], port
+
+        l2vpn_data = self.create_new_l2vpn(vlan='1060')
+        l2vpn_id = l2vpn_data['id']
+
+        # Removing vlan
+        payload = {
+        "sdx_vlan_range": [[100,200]]
+        }
+        response = requests.post(f"{api_url_ampath}/interfaces/{interfaces_id}/metadata", json=payload)
+        assert response.status_code == 201, response.text
+
+        # Force to send the topology to the SDX-LC
+        sdx_api = KYTOS_SDX_API % 'ampath'
+        response = requests.post(f"{sdx_api}/topology/2.0.0")
+        assert response.status_code == 200, response.text
+
+        time.sleep(15)
+
+        response = requests.get(API_URL)
+        assert response.status_code == 200, response.text
+        l2vpn_response = response.json()
+        l2vpn_response = l2vpn_response.get(l2vpn_id)
+        assert l2vpn_response.get("status") == "error", l2vpn_response
+    
+    @pytest.mark.xfail(reason="The L2VPN path associated with VLAN 1070 remains unchanged after modifying the VLAN range to [100–200]")
+    def test_107_removing_vlan_nni_with_alternate_path(self):
         """
-        Use Case 11: OXPO sends a topology update with a service no longer being supported on a certain Port
+        Use Case 10: OXPO sends a topology update with a changed VLAN range is for any of the services supported.
         """
-        
+
+        interfaces_id = 'aa:00:00:00:00:00:00:01:40'
+        interface_name = 'Ampath1-eth40'
+        ampath_api = KYTOS_API % 'ampath'
+        api_url_ampath = f'{ampath_api}/topology/v3'
+        payload = {
+        "sdx_vlan_range": [[100,200], [1000, 2000]]
+        }
+        response = requests.post(f"{api_url_ampath}/interfaces/{interfaces_id}/metadata", json=payload)
+        assert response.status_code == 201, response.text
+
+        # Force to send the topology to the SDX-LC
+        sdx_api = KYTOS_SDX_API % 'ampath'
+        response = requests.post(f"{sdx_api}/topology/2.0.0")
+        assert response.status_code == 200, response.text
+
+        time.sleep(15)
+
+        response = requests.get(API_URL_TOPO)
+        data = response.json()
+        for node in data['nodes']: 
+            for port in node['ports']:
+                if port['name'] == interface_name:
+                    assert port['services']['l2vpn_ptp']['vlan_range'] == [[100,200], [1000, 2000]], port
+
+        l2vpn_data = self.create_new_l2vpn(vlan='1070')
+        l2vpn_id = l2vpn_data['id']
+
+        # Removing vlan
+        payload = {
+        "sdx_vlan_range": [[100,200]]
+        }
+        response = requests.post(f"{api_url_ampath}/interfaces/{interfaces_id}/metadata", json=payload)
+        assert response.status_code == 201, response.text
+
+        # Force to send the topology to the SDX-LC
+        sdx_api = KYTOS_SDX_API % 'ampath'
+        response = requests.post(f"{sdx_api}/topology/2.0.0")
+        assert response.status_code == 200, response.text
+
+        time.sleep(15)
+
+        response = requests.get(API_URL)
+        assert response.status_code == 200, response.text
+        l2vpn_response = response.json()
+        l2vpn_response = l2vpn_response.get(l2vpn_id)
+        assert l2vpn_response.get("status") == "up", l2vpn_response
+
+        current_path = '-'.join(['_'.join(n['port_id'].split(':')[-2:]) for n in l2vpn_response['current_path']])
+        assert 'Ampath1_40' not in current_path, current_path
+
     @pytest.mark.xfail(reason="EVCs from OXPs where L2VPN creation does not fail are not empty")
     def test_120_l2vpn_provisioning_failure(self):
         """

--- a/tests/test_20_use_case_topology.py
+++ b/tests/test_20_use_case_topology.py
@@ -520,7 +520,6 @@ class TestE2ETopologyUseCases:
         """
         Use Case 10: OXPO sends a topology update with a changed VLAN range is for any of the services supported.
         """
-
         interfaces_id = 'aa:00:00:00:00:00:00:01:50'
         interface_name = 'Ampath1-eth50'
         ampath_api = KYTOS_API % 'ampath'

--- a/tests/test_20_use_case_topology.py
+++ b/tests/test_20_use_case_topology.py
@@ -526,7 +526,7 @@ class TestE2ETopologyUseCases:
         ampath_api = KYTOS_API % 'ampath'
         api_url_ampath = f'{ampath_api}/topology/v3'
         payload = {
-        "sdx_vlan_range": [[100,200], [1000, 2000]]
+            "sdx_vlan_range": [[100,200], [1000, 2000]]
         }
         response = requests.post(f"{api_url_ampath}/interfaces/{interfaces_id}/metadata", json=payload)
         assert response.status_code == 201, response.text
@@ -550,7 +550,7 @@ class TestE2ETopologyUseCases:
 
         # Removing vlan
         payload = {
-        "sdx_vlan_range": [[100,200]]
+            "sdx_vlan_range": [[1100, 1500]]
         }
         response = requests.post(f"{api_url_ampath}/interfaces/{interfaces_id}/metadata", json=payload)
         assert response.status_code == 201, response.text
@@ -579,7 +579,7 @@ class TestE2ETopologyUseCases:
         ampath_api = KYTOS_API % 'ampath'
         api_url_ampath = f'{ampath_api}/topology/v3'
         payload = {
-        "sdx_vlan_range": [[100,200], [1000, 2000]]
+            "sdx_vlan_range": [[100,200], [1000, 2000]]
         }
         response = requests.post(f"{api_url_ampath}/interfaces/{interfaces_id}/metadata", json=payload)
         assert response.status_code == 201, response.text
@@ -603,7 +603,7 @@ class TestE2ETopologyUseCases:
 
         # Removing vlan
         payload = {
-        "sdx_vlan_range": [[100,200]]
+            "sdx_vlan_range": [[1100, 1500]]
         }
         response = requests.post(f"{api_url_ampath}/interfaces/{interfaces_id}/metadata", json=payload)
         assert response.status_code == 201, response.text


### PR DESCRIPTION
This is for the case of removing a vlan range entry in Use case 10.

Use Case 10: OXPO sends a topology update with a changed VLAN range is for any of the services supported.

This PR includes two xfail tests:

`test_106_removing_vlan_uni`

`test_107_removing_vlan_nni_with_alternate_path`
