### PR TITLE
Test for the case of vlan [3000, 3000]

### DIFF
--- a/tests/test_20_use_case_topology.py
+++ b/tests/test_20_use_case_topology.py
@@ -1132,3 +1132,51 @@ class TestE2ETopologyUseCases:
         assert l2vpn_response.get("status") == "up"
         assert l2vpn_response['current_path'] != first_path
         assert new_vlan_range == first_vlan_range
+    
+    @pytest.mark.xfail(reason="It is not verified that the corresponding L2VPN is in the OXPs.")  
+    def test_142_create_l2vpn_with_vlan_range_same_items(self):
+        """
+        Use Case 14: User requests the creation of a L2VPN with VLAN Range.
+        """
+
+        # invalid range
+        l2vpn_payload = {
+            "name": "Test L2VPN creation with VLANs range",
+            "endpoints": [
+                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "3000:3000"},
+                {"port_id": "urn:sdx:port:sax.net:Sax01:50","vlan": "3000:3000"}
+            ]
+        }
+        response = requests.post(API_URL, json=l2vpn_payload)
+        assert response.status_code == 201, response.text
+        data = response.json()
+        l2vpn_id = data.get("service_id")
+
+        time.sleep(5)
+
+        response = requests.get(API_URL)
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert len(data) == 1, str(data)
+        assert l2vpn_id  in data, str(data)
+
+        # check the correspondent L2VPN is not on the OXPs.
+        url = 'http://%s:8181/api/kytos/mef_eline/v2/evc/'
+        ## ampath
+        ampath_url = url % 'ampath'
+        response = requests.get(ampath_url)
+        evcs = response.json()
+        found = 0
+        for evc in evcs.values():
+            if evc.get("uni_a", {}).get("tag", {}).get("value") == [[3000,3000]]:
+                found += 1
+        assert found == 1, response.text
+        ## sax
+        sax_url = url % 'sax'
+        response = requests.get(sax_url)
+        evcs = response.json()
+        found = 0
+        for evc in evcs.values():
+            if evc.get("uni_a", {}).get("tag", {}).get("value") == [[3000,3000]]:
+                found += 1
+        assert found == 1, response.text

--- a/tests/test_20_use_case_topology.py
+++ b/tests/test_20_use_case_topology.py
@@ -1133,12 +1133,11 @@ class TestE2ETopologyUseCases:
         assert l2vpn_response['current_path'] != first_path
         assert new_vlan_range == first_vlan_range
     
-    @pytest.mark.xfail(reason="It is not verified that the corresponding L2VPN is in the OXPs.")  
+    @pytest.mark.xfail(reason="Status is down and it is not verified that the corresponding L2VPN is in the OXPs.")  
     def test_142_create_l2vpn_with_vlan_range_same_items(self):
         """
         Use Case 14: User requests the creation of a L2VPN with VLAN Range.
         """
-
         l2vpn_payload = {
             "name": "Test L2VPN creation with VLANs range",
             "endpoints": [
@@ -1158,6 +1157,7 @@ class TestE2ETopologyUseCases:
         data = response.json()
         assert len(data) == 1, str(data)
         assert l2vpn_id  in data, str(data)
+        assert data.get(l2vpn_id).get("status") == "up", data
 
         # check the correspondent L2VPN is not on the OXPs.
         url = 'http://%s:8181/api/kytos/mef_eline/v2/evc/'
@@ -1179,3 +1179,4 @@ class TestE2ETopologyUseCases:
             if evc.get("uni_a", {}).get("tag", {}).get("value") == [[3000,3000]]:
                 found += 1
         assert found == 1, response.text
+

--- a/tests/test_20_use_case_topology.py
+++ b/tests/test_20_use_case_topology.py
@@ -1140,7 +1140,7 @@ class TestE2ETopologyUseCases:
         """
 
         l2vpn_payload = {
-            "name": "Test L2VPN creation with VLANs range",
+            "name": "Test 20 / 142 - L2VPN creation with one item VLANs range",
             "endpoints": [
                 {"port_id": "urn:sdx:port:ampath.net:Ampath3:50","vlan": "3000:3000"},
                 {"port_id": "urn:sdx:port:sax.net:Sax01:50","vlan": "3000:3000"}

--- a/tests/test_20_use_case_topology.py
+++ b/tests/test_20_use_case_topology.py
@@ -1139,7 +1139,6 @@ class TestE2ETopologyUseCases:
         Use Case 14: User requests the creation of a L2VPN with VLAN Range.
         """
 
-        # invalid range
         l2vpn_payload = {
             "name": "Test L2VPN creation with VLANs range",
             "endpoints": [

--- a/tests/test_20_use_case_topology.py
+++ b/tests/test_20_use_case_topology.py
@@ -1176,6 +1176,6 @@ class TestE2ETopologyUseCases:
         evcs = response.json()
         found = 0
         for evc in evcs.values():
-            if evc.get("uni_a", {}).get("tag", {}).get("value") == [[3000,3000]]:
+            if evc.get("uni_z", {}).get("tag", {}).get("value") == [[3000,3000]]:
                 found += 1
         assert found == 1, response.text


### PR DESCRIPTION
This test is to evaluate the creation of an L2VPN with a VLAN range where item1 = item2. The test is marked as xfail because it is not verified that the corresponding L2VPN is present in the OXPs.