### PR TITLE
L2VPN creation issue: OXP response with error

### DIFF
--- a/tests/test_20_use_case_topology.py
+++ b/tests/test_20_use_case_topology.py
@@ -1156,7 +1156,6 @@ class TestE2ETopologyUseCases:
         assert response.status_code == 200, response.text
         data = response.json()
         assert data.get(l2vpn_id).get("status") == "up", data
-          
         # check the correspondent L2VPN is not on the OXPs.
         url = 'http://%s:8181/api/kytos/mef_eline/v2/evc/'
         ## ampath

--- a/tests/test_20_use_case_topology.py
+++ b/tests/test_20_use_case_topology.py
@@ -1137,7 +1137,6 @@ class TestE2ETopologyUseCases:
         """
         Use Case 14: User requests the creation of a L2VPN with VLAN Range.
         """
-
         l2vpn_payload = {
             "name": "Test 20 / 142 - L2VPN creation with one item VLANs range",
             "endpoints": [

--- a/tests/test_20_use_case_topology.py
+++ b/tests/test_20_use_case_topology.py
@@ -1133,11 +1133,12 @@ class TestE2ETopologyUseCases:
         assert l2vpn_response['current_path'] != first_path
         assert new_vlan_range == first_vlan_range
     
-    @pytest.mark.xfail(reason="Status is down and it is not verified that the corresponding L2VPN is in the OXPs.")  
+    #@pytest.mark.xfail(reason="Status is down and encountered a 500 error from OXPS")  
     def test_142_create_l2vpn_with_vlan_range_same_items(self):
         """
         Use Case 14: User requests the creation of a L2VPN with VLAN Range.
         """
+
         l2vpn_payload = {
             "name": "Test 20 / 142 - L2VPN creation with one item VLANs range",
             "endpoints": [
@@ -1155,10 +1156,12 @@ class TestE2ETopologyUseCases:
         response = requests.get(API_URL)
         assert response.status_code == 200, response.text
         data = response.json()
-        assert len(data) == 1, str(data)
-        assert l2vpn_id  in data, str(data)
-        assert data.get(l2vpn_id).get("status") == "up", data
-
+        data_l2vpn = data.get(l2vpn_id)
+        oxp_response = data_l2vpn.get("oxp_response")
+        assert oxp_response.get("ampath.net")[0] == 201
+        assert oxp_response.get("sax.net")[0] == 201
+        assert data_l2vpn.get("status") == "up", data
+          
         # check the correspondent L2VPN is not on the OXPs.
         url = 'http://%s:8181/api/kytos/mef_eline/v2/evc/'
         ## ampath

--- a/tests/test_20_use_case_topology.py
+++ b/tests/test_20_use_case_topology.py
@@ -1133,7 +1133,6 @@ class TestE2ETopologyUseCases:
         assert l2vpn_response['current_path'] != first_path
         assert new_vlan_range == first_vlan_range
     
-    #@pytest.mark.xfail(reason="Status is down and encountered a 500 error from OXPS")  
     def test_142_create_l2vpn_with_vlan_range_same_items(self):
         """
         Use Case 14: User requests the creation of a L2VPN with VLAN Range.
@@ -1156,11 +1155,7 @@ class TestE2ETopologyUseCases:
         response = requests.get(API_URL)
         assert response.status_code == 200, response.text
         data = response.json()
-        data_l2vpn = data.get(l2vpn_id)
-        oxp_response = data_l2vpn.get("oxp_response")
-        assert oxp_response.get("ampath.net")[0] == 201
-        assert oxp_response.get("sax.net")[0] == 201
-        assert data_l2vpn.get("status") == "up", data
+        assert data.get(l2vpn_id).get("status") == "up", data
           
         # check the correspondent L2VPN is not on the OXPs.
         url = 'http://%s:8181/api/kytos/mef_eline/v2/evc/'
@@ -1182,4 +1177,3 @@ class TestE2ETopologyUseCases:
             if evc.get("uni_z", {}).get("tag", {}).get("value") == [[3000,3000]]:
                 found += 1
         assert found == 1, response.text
-


### PR DESCRIPTION
This PR includes the output and logs related to issue https://github.com/atlanticwave-sdx/sdx-controller/issues/500#issuecomment-3406546848. 

When creating an L2VPN with a range such as 3000:3000, the API returns a 200 OK response, but the service status is reported as `down` and the OXPs responses also includes an error message:

```
{'3555afe7-f99f-49b4-a1ac-59db3cc9ad4a': {'archived_date': 0, 'current_path': [{'port_id': 'urn:sdx:port:ampath.net:Ampath3:50', 'vlan': '3000:3000'}, {'port_id': 'urn:sdx:port:ampath.net:Ampath1:40', 'vlan': '3000:3000'}, {'port_id': 'urn:sdx:port:sax.net:Sax01:40', 'vlan': '3000:3000'}, {'port_id': 'urn:sdx:port:sax.net:Sax01:50', 'vlan': '3000:3000'}], 'description': None, 'endpoints': [{'port_id': 'urn:sdx:port:ampath.net:Ampath3:50', 'vlan': '3000:3000'}, {'port_id': 'urn:sdx:port:sax.net:Sax01:50', 'vlan': '3000:3000'}], 'name': 'Test 20 / 142 - L2VPN creation with one item VLANs range', 'oxp_response': {'ampath.net': [500, {'msg': 'Failed to parse OXP response. Please check the OXP logs.'}], 'sax.net': [500, {'msg': 'Failed to parse OXP response. Please check the OXP logs.'}]}, 'service_id': '3555afe7-f99f-49b4-a1ac-59db3cc9ad4a', 'status': 'down'}}
```

The attached output should help with troubleshooting and identifying the root cause.

<img width="1081" height="441" alt="Screenshot 2025-10-20 at 15 35 25" src="https://github.com/user-attachments/assets/293a2d00-d5fa-448c-9226-97420dbf1df7" />
