### PR TITLE
Adding sleep to the begin of some tests to avoid L2VPN created to be left over

### DIFF
--- a/tests/test_07_l2vpn_return_codes.py
+++ b/tests/test_07_l2vpn_return_codes.py
@@ -27,6 +27,9 @@ class TestE2EReturnCodesEditL2vpn:
    
     @classmethod
     def setup_method(cls):
+        # give enough time so that previous L2VPN gets created or topology update gets sent
+        time.sleep(3)
+
         api_url = SDX_CONTROLLER + '/l2vpn/1.0'
         response = requests.get(api_url)
         assert response.status_code == 200, response.text

--- a/tests/test_20_use_case_topology.py
+++ b/tests/test_20_use_case_topology.py
@@ -53,6 +53,9 @@ class TestE2ETopologyUseCases:
     @classmethod
     def setup_method(cls):
         """Reset network configuration before each test."""
+        # give enough time so that previous L2VPN gets created or topology update gets sent
+        time.sleep(3)
+
         api_url = SDX_CONTROLLER + '/l2vpn/1.0'
         response = requests.get(api_url)
         assert response.status_code == 200, response.text


### PR DESCRIPTION
Fix #127 

As pointed out by @YufengXin, it may happen that some L2VPN created through the test are still being processed when a assertion failed or the test just finishes, and that way we can left some L2VPN over to next tests.